### PR TITLE
Implement a comprehensive affiliate referral system for sellers

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,5 +1,5 @@
 run = "npm run dev"
-modules = ["python-3.11", "postgresql-16", "nodejs-22"]
+modules = ["python-3.11", "nodejs-22", "postgresql-16"]
 
 [nix]
 channel = "stable-22_11"

--- a/__tests__/api/affiliates/process-payouts.test.ts
+++ b/__tests__/api/affiliates/process-payouts.test.ts
@@ -1,0 +1,351 @@
+/** @jest-environment node */
+
+// Stripe SDK is imported by the handler; stub the constructor before importing
+// the route so we don't try to talk to the real API. Individual tests reach in
+// via the captured instance below.
+// Babel-jest hoists `jest.mock` calls above all imports AND above the rest of
+// the file's top-level statements. Because `import handler from
+// "@/pages/api/affiliates/process-payouts"` triggers `new Stripe(...)` at the
+// route module's top level, the Stripe mock factory is invoked BEFORE any of
+// our top-level `const x = jest.fn()` declarations have executed. We work
+// around this by:
+//   1. building the spies inside the factory itself (so they exist by the
+//      time the route's `new Stripe(...)` runs), and
+//   2. exposing them on the mock module so the test file can grab them after
+//      the import.
+jest.mock("stripe", () => {
+  const transfersCreate = jest.fn();
+  const accountsRetrieve = jest.fn();
+  const Ctor: any = jest.fn().mockImplementation(() => ({
+    transfers: { create: transfersCreate },
+    accounts: { retrieve: accountsRetrieve },
+  }));
+  Ctor.__transfersCreate = transfersCreate;
+  Ctor.__accountsRetrieve = accountsRetrieve;
+  return Ctor;
+});
+
+jest.mock("@getalby/lightning-tools", () => ({
+  LightningAddress: jest.fn().mockImplementation(() => ({
+    fetch: jest.fn(),
+    requestInvoice: () => ({ paymentRequest: "lnbc1pfake" }),
+  })),
+}));
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const StripeMock: any = require("stripe");
+const stripeTransfersCreate: jest.Mock = StripeMock.__transfersCreate;
+const stripeAccountsRetrieve: jest.Mock = StripeMock.__accountsRetrieve;
+
+// Whole-module mock for the affiliates DB layer. We re-export only the surface
+// the handler actually reaches for.
+jest.mock("@/utils/db/affiliates", () => ({
+  ADVISORY_LOCK_KEYS: {
+    weekly: 100,
+    biweekly: 101,
+    monthly: 102,
+    daily: 103,
+    every_sale: 104,
+  },
+  MAX_PAYOUT_FAILURES: 3,
+  affiliateLockKey: (id: number) => 200 + id,
+  clearPayoutFailure: jest.fn(),
+  createPayoutAndSettle: jest.fn(),
+  getAffiliateById: jest.fn(),
+  getPayableReferralBundle: jest.fn(),
+  getSellerEmailForPubkey: jest.fn(),
+  markReferralsPayableBySchedule: jest.fn(),
+  recordPayoutFailure: jest.fn(),
+  tryAdvisoryLock: jest.fn(),
+}));
+
+jest.mock("@/utils/db/db-service", () => {
+  const queryFn = jest.fn();
+  const release = jest.fn();
+  return {
+    __queryFn: queryFn,
+    __release: release,
+    getDbPool: () => ({
+      connect: async () => ({ query: queryFn, release }),
+    }),
+  };
+});
+const dbServiceMock: any = require("@/utils/db/db-service");
+const queryFn: jest.Mock = dbServiceMock.__queryFn;
+
+jest.mock("@/utils/rate-limit", () => ({
+  applyRateLimit: jest.fn(() => true),
+}));
+
+jest.mock("@/utils/email/email-service", () => ({
+  sendAffiliatePaidEmail: jest.fn().mockResolvedValue(true),
+  sendAffiliatePausedToAffiliate: jest.fn().mockResolvedValue(true),
+  sendAffiliatePausedToSeller: jest.fn().mockResolvedValue(true),
+}));
+import * as emailService from "@/utils/email/email-service";
+const sendPaid = emailService.sendAffiliatePaidEmail as unknown as jest.Mock;
+const sendPausedAffiliate =
+  emailService.sendAffiliatePausedToAffiliate as unknown as jest.Mock;
+const sendPausedSeller =
+  emailService.sendAffiliatePausedToSeller as unknown as jest.Mock;
+
+import handler from "@/pages/api/affiliates/process-payouts";
+import {
+  clearPayoutFailure,
+  createPayoutAndSettle,
+  getAffiliateById,
+  getPayableReferralBundle,
+  getSellerEmailForPubkey,
+  markReferralsPayableBySchedule,
+  recordPayoutFailure,
+  tryAdvisoryLock,
+} from "@/utils/db/affiliates";
+
+const mAff = getAffiliateById as jest.Mock;
+const mBundles = getPayableReferralBundle as jest.Mock;
+const mMarkPayable = markReferralsPayableBySchedule as jest.Mock;
+const mSettle = createPayoutAndSettle as jest.Mock;
+const mRecordFailure = recordPayoutFailure as jest.Mock;
+const mClearFailure = clearPayoutFailure as jest.Mock;
+const mLock = tryAdvisoryLock as jest.Mock;
+const mSellerEmail = getSellerEmailForPubkey as jest.Mock;
+
+function mockRes() {
+  const r: any = {
+    statusCode: 200,
+    body: undefined,
+    status(c: number) {
+      this.statusCode = c;
+      return this;
+    },
+    json(b: any) {
+      this.body = b;
+      return this;
+    },
+    setHeader() {},
+    getHeader() {},
+  };
+  return r;
+}
+
+const baseAffiliate = {
+  id: 7,
+  seller_pubkey: "a".repeat(64),
+  name: "Alice",
+  email: "alice@example.com",
+  affiliate_pubkey: "b".repeat(64),
+  invite_token: "tok_alice",
+  invite_claimed_at: new Date(),
+  lightning_address: null,
+  stripe_account_id: "acct_test",
+  notes: null,
+  payouts_enabled: true,
+  payout_failure_count: 0,
+  last_payout_failure_at: null,
+  last_payout_failure_reason: null,
+  email_notifications_enabled: true,
+  stripe_charges_enabled: true,
+  stripe_payouts_enabled: true,
+  stripe_onboarding_complete: true,
+  created_at: new Date(),
+  updated_at: new Date(),
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  process.env.AFFILIATE_PAYOUT_CRON_SECRET = "test-cron-secret";
+  process.env.AFFILIATE_UNSUBSCRIBE_SECRET = "x".repeat(32);
+  process.env.STRIPE_SECRET_KEY = "sk_test_x";
+
+  mLock.mockImplementation(async () => ({
+    release: jest.fn().mockResolvedValue(undefined),
+  }));
+  mAff.mockResolvedValue({ ...baseAffiliate });
+  mBundles.mockResolvedValue([
+    {
+      currency: "usd",
+      total_smallest: "1000",
+      referral_ids: [11, 12],
+      seller_pubkey: baseAffiliate.seller_pubkey,
+    },
+  ]);
+  mMarkPayable.mockResolvedValue({ promoted: 0 });
+  mSettle.mockResolvedValue({ payoutId: 999 });
+  mRecordFailure.mockResolvedValue(baseAffiliate);
+  mClearFailure.mockResolvedValue(undefined);
+  mSellerEmail.mockResolvedValue("seller@example.com");
+  stripeTransfersCreate.mockResolvedValue({
+    id: "tr_123",
+    amount: 1000,
+    currency: "usd",
+  });
+  stripeAccountsRetrieve.mockResolvedValue({
+    charges_enabled: true,
+    payouts_enabled: true,
+  });
+  queryFn.mockResolvedValue({ rows: [{ affiliate_id: 7 }] });
+});
+
+function callHandler(
+  overrides: Partial<{
+    authorization: string;
+    query: Record<string, string>;
+  }> = {}
+) {
+  const req: any = {
+    method: "POST",
+    query: { schedule: "monthly", ...(overrides.query ?? {}) },
+    headers: {
+      authorization:
+        overrides.authorization ??
+        `Bearer ${process.env.AFFILIATE_PAYOUT_CRON_SECRET}`,
+    },
+    body: {},
+  };
+  const res = mockRes();
+  return handler(req as any, res as any).then(() => res);
+}
+
+describe("process-payouts auth + locking", () => {
+  it("rejects non-POST", async () => {
+    const req: any = { method: "GET", query: {}, headers: {} };
+    const res = mockRes();
+    await handler(req, res as any);
+    expect(res.statusCode).toBe(405);
+  });
+
+  it("rejects missing bearer secret", async () => {
+    const res = await callHandler({ authorization: "" });
+    expect(res.statusCode).toBe(401);
+    expect(mMarkPayable).not.toHaveBeenCalled();
+  });
+
+  it("rejects when AFFILIATE_PAYOUT_CRON_SECRET is unset", async () => {
+    delete process.env.AFFILIATE_PAYOUT_CRON_SECRET;
+    const req: any = {
+      method: "POST",
+      query: { schedule: "monthly" },
+      headers: { authorization: "Bearer anything" },
+      body: {},
+    };
+    const res = mockRes();
+    await handler(req, res as any);
+    expect(res.statusCode).toBe(500);
+  });
+
+  it("rejects unknown schedule", async () => {
+    const res = await callHandler({ query: { schedule: "annually" } });
+    expect(res.statusCode).toBe(400);
+  });
+
+  it("returns 409 when the schedule advisory lock is held", async () => {
+    mLock.mockResolvedValueOnce(null);
+    const res = await callHandler();
+    expect(res.statusCode).toBe(409);
+  });
+});
+
+describe("process-payouts business rules", () => {
+  it("skips affiliates whose payouts_enabled flag is off", async () => {
+    mAff.mockResolvedValueOnce({ ...baseAffiliate, payouts_enabled: false });
+    const res = await callHandler();
+    expect(res.statusCode).toBe(200);
+    expect(stripeTransfersCreate).not.toHaveBeenCalled();
+    expect(res.body.processed[0]).toMatchObject({
+      affiliateId: 7,
+      success: false,
+    });
+    expect(res.body.processed[0].error).toMatch(/disabled/i);
+  });
+
+  it("dry-run does not promote referrals or move money", async () => {
+    const res = await callHandler({
+      query: { schedule: "monthly", dryRun: "1" },
+    });
+    expect(res.statusCode).toBe(200);
+    expect(mMarkPayable).not.toHaveBeenCalled();
+    expect(stripeTransfersCreate).not.toHaveBeenCalled();
+  });
+
+  it("happy path: Stripe transfer fires, referrals marked paid, success email sent", async () => {
+    const res = await callHandler();
+    expect(res.statusCode).toBe(200);
+    expect(stripeTransfersCreate).toHaveBeenCalledTimes(1);
+    const args = stripeTransfersCreate.mock.calls[0]![0];
+    expect(args).toMatchObject({
+      amount: 1000,
+      currency: "usd",
+      destination: "acct_test",
+    });
+    // Idempotency key MUST be stable + non-empty so retries dedupe.
+    expect(stripeTransfersCreate.mock.calls[0]![1].idempotencyKey).toBeTruthy();
+    expect(mSettle).toHaveBeenCalledWith(
+      expect.objectContaining({
+        affiliateId: 7,
+        method: "stripe",
+        amountSmallest: 1000,
+        currency: "usd",
+        externalRef: "tr_123",
+        referralIds: [11, 12],
+      })
+    );
+    expect(mClearFailure).toHaveBeenCalledWith(7);
+    expect(sendPaid).toHaveBeenCalledTimes(1);
+    expect(sendPaid.mock.calls[0]![1].unsubscribeUrl).toMatch(/unsubscribe/);
+  });
+
+  it("does not send the paid email when affiliate opted out", async () => {
+    mAff.mockResolvedValueOnce({
+      ...baseAffiliate,
+      email_notifications_enabled: false,
+    });
+    const res = await callHandler();
+    expect(res.statusCode).toBe(200);
+    expect(sendPaid).not.toHaveBeenCalled();
+  });
+
+  it("Stripe transfer failure records a failure and never marks paid", async () => {
+    stripeTransfersCreate.mockRejectedValueOnce(new Error("acct closed"));
+    const res = await callHandler();
+    expect(res.statusCode).toBe(200);
+    expect(mRecordFailure).toHaveBeenCalledWith(
+      7,
+      expect.stringMatching(/acct closed/)
+    );
+    expect(mSettle).not.toHaveBeenCalled();
+  });
+
+  it("auto-disables and notifies after MAX_PAYOUT_FAILURES is reached", async () => {
+    stripeTransfersCreate.mockRejectedValueOnce(new Error("blocked"));
+    // First call: initial fetch at top of loop. Second call: re-read after
+    // recordPayoutFailure to detect that the threshold was crossed.
+    mAff.mockResolvedValueOnce({ ...baseAffiliate }).mockResolvedValueOnce({
+      ...baseAffiliate,
+      payouts_enabled: false,
+      payout_failure_count: 3,
+      last_payout_failure_reason: "blocked",
+    });
+    const res = await callHandler();
+    expect(res.statusCode).toBe(200);
+    expect(sendPausedAffiliate).toHaveBeenCalledTimes(1);
+    expect(sendPausedAffiliate.mock.calls[0]![1].unsubscribeUrl).toMatch(
+      /unsubscribe/
+    );
+    expect(sendPausedSeller).toHaveBeenCalledTimes(1);
+  });
+
+  it("respects the per-currency minimum payout threshold", async () => {
+    mBundles.mockResolvedValueOnce([
+      {
+        currency: "usd",
+        total_smallest: "10",
+        referral_ids: [1],
+        seller_pubkey: baseAffiliate.seller_pubkey,
+      },
+    ]);
+    const res = await callHandler();
+    expect(res.statusCode).toBe(200);
+    expect(stripeTransfersCreate).not.toHaveBeenCalled();
+    expect(res.body.processed[0].error).toMatch(/minimum/i);
+  });
+});

--- a/__tests__/api/affiliates/record-referral.test.ts
+++ b/__tests__/api/affiliates/record-referral.test.ts
@@ -1,0 +1,181 @@
+/** @jest-environment node */
+
+jest.mock("@/utils/db/affiliates", () => ({
+  lookupAffiliateCode: jest.fn(),
+  isAffiliateCodeValid: jest.fn(),
+  isSelfReferral: jest.fn(() => false),
+  computeBuyerDiscountSmallest: jest.fn(),
+  computeRebateSmallest: jest.fn(),
+  recordReferral: jest.fn(),
+}));
+
+jest.mock("@/utils/rate-limit", () => ({
+  applyRateLimit: jest.fn(() => true),
+}));
+
+import handler from "@/pages/api/affiliates/record-referral";
+import {
+  computeBuyerDiscountSmallest,
+  computeRebateSmallest,
+  isAffiliateCodeValid,
+  isSelfReferral,
+  lookupAffiliateCode,
+  recordReferral,
+} from "@/utils/db/affiliates";
+
+const mLookup = lookupAffiliateCode as jest.Mock;
+const mValid = isAffiliateCodeValid as jest.Mock;
+const mSelf = isSelfReferral as jest.Mock;
+const mDiscount = computeBuyerDiscountSmallest as jest.Mock;
+const mRebate = computeRebateSmallest as jest.Mock;
+const mRecord = recordReferral as jest.Mock;
+
+function mockRes() {
+  const r: any = {
+    statusCode: 200,
+    body: undefined,
+    status(c: number) {
+      this.statusCode = c;
+      return this;
+    },
+    json(b: any) {
+      this.body = b;
+      return this;
+    },
+    setHeader() {},
+    getHeader() {},
+  };
+  return r;
+}
+
+const baseCode = {
+  id: 1,
+  affiliate_id: 7,
+  buyer_discount_type: "percent" as const,
+  buyer_discount_value: "5",
+  rebate_type: "percent" as const,
+  rebate_value: "10",
+  payout_schedule: "monthly",
+  currency: "usd",
+  affiliate: { name: "Alice", affiliate_pubkey: "aff_pk" },
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mDiscount.mockReturnValue(500);
+  mRebate.mockReturnValue(950);
+});
+
+describe("/api/affiliates/record-referral", () => {
+  it("rejects non-POST", async () => {
+    const req: any = { method: "GET" };
+    const res = mockRes();
+    await handler(req, res);
+    expect(res.statusCode).toBe(405);
+  });
+
+  it("returns 400 when fields are missing", async () => {
+    const req: any = { method: "POST", body: { sellerPubkey: "s" } };
+    const res = mockRes();
+    await handler(req, res);
+    expect(res.statusCode).toBe(400);
+  });
+
+  it("rejects fixed-amount currency mismatch", async () => {
+    mLookup.mockResolvedValue({
+      ...baseCode,
+      buyer_discount_type: "fixed",
+      currency: "usd",
+    });
+    mValid.mockResolvedValue(true);
+    const req: any = {
+      method: "POST",
+      body: {
+        sellerPubkey: "seller",
+        code: "ALICE",
+        orderId: "o1",
+        paymentRail: "stripe",
+        grossSubtotalSmallest: 10000,
+        currency: "sats",
+      },
+    };
+    const res = mockRes();
+    await handler(req, res);
+    expect(res.statusCode).toBe(400);
+    expect(String(res.body.error)).toMatch(/currency/i);
+  });
+
+  it("rejects self-referral", async () => {
+    mLookup.mockResolvedValue(baseCode);
+    mValid.mockResolvedValue(true);
+    mSelf.mockReturnValueOnce(true);
+    const req: any = {
+      method: "POST",
+      body: {
+        sellerPubkey: "seller",
+        code: "ALICE",
+        orderId: "o1",
+        paymentRail: "stripe",
+        grossSubtotalSmallest: 10000,
+        currency: "usd",
+      },
+    };
+    const res = mockRes();
+    await handler(req, res);
+    expect(res.statusCode).toBe(400);
+    expect(String(res.body.error)).toMatch(/self-referral/i);
+  });
+
+  it("records a referral and returns the computed amounts", async () => {
+    mLookup.mockResolvedValue(baseCode);
+    mValid.mockResolvedValue(true);
+    mRecord.mockResolvedValue({ id: 42 });
+    const req: any = {
+      method: "POST",
+      body: {
+        sellerPubkey: "seller",
+        code: "ALICE",
+        orderId: "o1",
+        paymentRail: "stripe",
+        grossSubtotalSmallest: 10000,
+        currency: "usd",
+      },
+    };
+    const res = mockRes();
+    await handler(req, res);
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toMatchObject({
+      success: true,
+      referralId: 42,
+      buyerDiscountSmallest: 500,
+      rebateSmallest: 950,
+    });
+    expect(mRecord).toHaveBeenCalledWith(
+      expect.objectContaining({
+        initialStatus: "pending",
+        realtimeTransferRef: null,
+      })
+    );
+  });
+
+  it("surfaces max_uses contention as 409", async () => {
+    mLookup.mockResolvedValue(baseCode);
+    mValid.mockResolvedValue(true);
+    mRecord.mockRejectedValue(new Error("max_uses reached"));
+    const req: any = {
+      method: "POST",
+      body: {
+        sellerPubkey: "seller",
+        code: "ALICE",
+        orderId: "o1",
+        paymentRail: "stripe",
+        grossSubtotalSmallest: 10000,
+        currency: "usd",
+      },
+    };
+    const res = mockRes();
+    await handler(req, res);
+    expect(res.statusCode).toBe(409);
+    expect(String(res.body.error)).toMatch(/max_uses/);
+  });
+});

--- a/__tests__/api/affiliates/validate.test.ts
+++ b/__tests__/api/affiliates/validate.test.ts
@@ -1,0 +1,142 @@
+/** @jest-environment node */
+
+jest.mock("@/utils/db/affiliates", () => ({
+  lookupAffiliateCode: jest.fn(),
+  isAffiliateCodeValid: jest.fn(),
+  computeBuyerDiscountSmallest: jest.fn(),
+  computeRebateSmallest: jest.fn(),
+}));
+
+jest.mock("@/utils/rate-limit", () => ({
+  applyRateLimit: jest.fn(() => true),
+}));
+
+import handler from "@/pages/api/affiliates/validate";
+import {
+  computeBuyerDiscountSmallest,
+  computeRebateSmallest,
+  isAffiliateCodeValid,
+  lookupAffiliateCode,
+} from "@/utils/db/affiliates";
+
+const mLookup = lookupAffiliateCode as jest.Mock;
+const mValid = isAffiliateCodeValid as jest.Mock;
+const mDiscount = computeBuyerDiscountSmallest as jest.Mock;
+const mRebate = computeRebateSmallest as jest.Mock;
+
+function mockRes() {
+  const r: any = {
+    statusCode: 200,
+    body: undefined,
+    status(c: number) {
+      this.statusCode = c;
+      return this;
+    },
+    json(b: any) {
+      this.body = b;
+      return this;
+    },
+    setHeader() {},
+    getHeader() {},
+  };
+  return r;
+}
+
+const baseCode = {
+  id: 1,
+  affiliate_id: 7,
+  buyer_discount_type: "fixed" as const,
+  buyer_discount_value: "500",
+  rebate_type: "percent" as const,
+  rebate_value: "10",
+  payout_schedule: "monthly",
+  currency: "usd",
+  affiliate: { name: "Alice", affiliate_pubkey: null },
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mDiscount.mockReturnValue(500);
+  mRebate.mockReturnValue(50);
+});
+
+describe("/api/affiliates/validate currency guard", () => {
+  it("returns 405 for non-GET", async () => {
+    const req: any = { method: "POST", query: {} };
+    const res = mockRes();
+    await handler(req, res);
+    expect(res.statusCode).toBe(405);
+  });
+
+  it("rejects a fixed-amount USD code applied to a sats invoice", async () => {
+    mLookup.mockResolvedValue(baseCode);
+    mValid.mockResolvedValue(true);
+    const req: any = {
+      method: "GET",
+      query: {
+        sellerPubkey: "seller",
+        code: "ALICE",
+        currency: "sats",
+        grossSmallest: "10000",
+      },
+    };
+    const res = mockRes();
+    await handler(req, res);
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toEqual({ valid: false });
+  });
+
+  it("accepts matching currency and returns rebate preview", async () => {
+    mLookup.mockResolvedValue(baseCode);
+    mValid.mockResolvedValue(true);
+    const req: any = {
+      method: "GET",
+      query: {
+        sellerPubkey: "seller",
+        code: "ALICE",
+        currency: "USD",
+        grossSmallest: "10000",
+      },
+    };
+    const res = mockRes();
+    await handler(req, res);
+    expect(res.statusCode).toBe(200);
+    expect(res.body.valid).toBe(true);
+    expect(res.body.buyerDiscountSmallest).toBe(500);
+    expect(res.body.rebateSmallest).toBe(50);
+  });
+
+  it("allows a percent-only code across currencies", async () => {
+    mLookup.mockResolvedValue({
+      ...baseCode,
+      buyer_discount_type: "percent",
+      buyer_discount_value: "5",
+      rebate_type: "percent",
+      rebate_value: "10",
+    });
+    mValid.mockResolvedValue(true);
+    const req: any = {
+      method: "GET",
+      query: {
+        sellerPubkey: "seller",
+        code: "ALICE",
+        currency: "sats",
+        grossSmallest: "1000",
+      },
+    };
+    const res = mockRes();
+    await handler(req, res);
+    expect(res.body.valid).toBe(true);
+  });
+
+  it("returns valid:false for an unknown code without leaking which input was wrong", async () => {
+    mLookup.mockResolvedValue(null);
+    const req: any = {
+      method: "GET",
+      query: { sellerPubkey: "seller", code: "BAD" },
+    };
+    const res = mockRes();
+    await handler(req, res);
+    expect(res.body).toEqual({ valid: false });
+  });
+});

--- a/__tests__/utils/db/affiliates.test.ts
+++ b/__tests__/utils/db/affiliates.test.ts
@@ -1,0 +1,117 @@
+/**
+ * Pure-function unit tests for the affiliate helper module. We only cover
+ * the math/predicate helpers that don't need a Postgres connection — DB
+ * integration is exercised end-to-end in staging.
+ *
+ * We mock `@/utils/db/db-service` because importing it transitively pulls
+ * in nostr-tools / @noble through `utils/url-slugs.ts`, which jest's
+ * default transformer can't parse. The pure helpers we test here never
+ * touch the pool, so the mock is just a stub.
+ */
+jest.mock("@/utils/db/db-service", () => ({
+  getDbPool: () => ({
+    connect: () => ({ query: jest.fn(), release: jest.fn() }),
+  }),
+}));
+
+import {
+  computeBuyerDiscountSmallest,
+  computeClawbackSmallest,
+  computeRebateSmallest,
+  computeRefundRatio,
+  isSelfReferral,
+  MAX_PAYOUT_FAILURES,
+} from "@/utils/db/affiliates";
+
+describe("computeBuyerDiscountSmallest", () => {
+  it("returns 0 for non-positive gross", () => {
+    expect(computeBuyerDiscountSmallest(0, "percent", 10)).toBe(0);
+    expect(computeBuyerDiscountSmallest(-100, "percent", 10)).toBe(0);
+  });
+
+  it("applies a percentage cleanly", () => {
+    expect(computeBuyerDiscountSmallest(10_000, "percent", 10)).toBe(1_000);
+    expect(computeBuyerDiscountSmallest(9_999, "percent", 33)).toBe(3_299);
+  });
+
+  it("caps a percentage at 100", () => {
+    expect(computeBuyerDiscountSmallest(1_000, "percent", 250)).toBe(999);
+  });
+
+  it("treats fixed values as major units (cents)", () => {
+    expect(computeBuyerDiscountSmallest(10_000, "fixed", 5)).toBe(500);
+  });
+
+  it("never lets a fixed cut equal or exceed gross", () => {
+    expect(computeBuyerDiscountSmallest(500, "fixed", 9)).toBe(499);
+  });
+});
+
+describe("computeRebateSmallest", () => {
+  it("applies a percentage to the net subtotal", () => {
+    expect(computeRebateSmallest(9_000, "percent", 10)).toBe(900);
+  });
+
+  it("caps at the net so we never owe more than the buyer paid", () => {
+    expect(computeRebateSmallest(100, "fixed", 5)).toBe(100);
+  });
+
+  it("returns 0 for a zero or negative net", () => {
+    expect(computeRebateSmallest(0, "percent", 50)).toBe(0);
+    expect(computeRebateSmallest(-10, "fixed", 1)).toBe(0);
+  });
+});
+
+describe("isSelfReferral", () => {
+  it("matches case-insensitively", () => {
+    expect(isSelfReferral("ABC", "abc")).toBe(true);
+    expect(isSelfReferral("abc", "ABC")).toBe(true);
+  });
+
+  it("returns false for distinct pubkeys", () => {
+    expect(isSelfReferral("abc", "def")).toBe(false);
+  });
+
+  it("returns false when the affiliate has not claimed yet", () => {
+    expect(isSelfReferral("abc", null)).toBe(false);
+    expect(isSelfReferral("abc", undefined)).toBe(false);
+  });
+});
+
+describe("computeRefundRatio", () => {
+  it("clamps to 1 on overshoot", () => {
+    expect(computeRefundRatio(100, 200)).toBe(1);
+  });
+
+  it("returns 0 when gross or refund is invalid", () => {
+    expect(computeRefundRatio(0, 50)).toBe(0);
+    expect(computeRefundRatio(100, 0)).toBe(0);
+    expect(computeRefundRatio(NaN, 50)).toBe(0);
+  });
+
+  it("returns the proportional fraction otherwise", () => {
+    expect(computeRefundRatio(1_000, 250)).toBeCloseTo(0.25);
+  });
+});
+
+describe("computeClawbackSmallest", () => {
+  it("scales the rebate down by the ratio", () => {
+    expect(computeClawbackSmallest(1_000, 0.25)).toBe(250);
+  });
+
+  it("clamps the ratio to 0..1", () => {
+    expect(computeClawbackSmallest(1_000, 1.5)).toBe(1_000);
+    expect(computeClawbackSmallest(1_000, -1)).toBe(0);
+  });
+
+  it("floors fractional cents", () => {
+    expect(computeClawbackSmallest(99, 0.5)).toBe(49);
+  });
+});
+
+describe("MAX_PAYOUT_FAILURES", () => {
+  it("is a sane positive integer", () => {
+    expect(Number.isInteger(MAX_PAYOUT_FAILURES)).toBe(true);
+    expect(MAX_PAYOUT_FAILURES).toBeGreaterThan(0);
+  });
+});

--- a/__tests__/utils/db/reverse-referrals-idempotency.test.ts
+++ b/__tests__/utils/db/reverse-referrals-idempotency.test.ts
@@ -1,0 +1,137 @@
+/**
+ * @jest-environment node
+ *
+ * Idempotency test for `reverseReferralsForOrder`. The seller-driven
+ * reverse-referral button can be clicked twice (or fired by the Stripe
+ * webhook AND clicked manually). The SQL `WHERE status IN
+ * ('pending','payable','paid')` clause is what makes the second call a
+ * no-op: rows already moved to 'cancelled' / 'refunded' simply aren't
+ * touched again.
+ *
+ * We exercise that contract here by mocking the pg client so the first call
+ * sees a pending row and the second call sees an empty rowset.
+ */
+
+const queryFn = jest.fn();
+const releaseFn = jest.fn();
+jest.mock("@/utils/db/db-service", () => ({
+  getDbPool: () => ({
+    connect: async () => ({ query: queryFn, release: releaseFn }),
+  }),
+}));
+
+import { reverseReferralsForOrder } from "@/utils/db/affiliates";
+
+describe("reverseReferralsForOrder idempotency", () => {
+  beforeEach(() => {
+    queryFn.mockReset();
+    releaseFn.mockReset();
+  });
+
+  it("first call cancels the pending row; second call is a no-op", async () => {
+    // -- Call #1 --
+    // BEGIN, SELECT (returns 1 row), UPDATE row -> cancelled, COMMIT.
+    queryFn
+      .mockResolvedValueOnce({ rows: [] }) // BEGIN
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            id: 101,
+            status: "pending",
+            rebate_smallest: "500",
+            refunded_smallest: "0",
+          },
+        ],
+      })
+      .mockResolvedValueOnce({ rows: [] }) // UPDATE
+      .mockResolvedValueOnce({ rows: [] }); // COMMIT
+
+    const first = await reverseReferralsForOrder({
+      orderId: "order-xyz",
+      sellerPubkey: "seller-pk",
+      refundEventRef: "manual:click-1",
+    });
+    expect(first).toEqual({
+      cancelled: 1,
+      refunded: 0,
+      partial: 0,
+      totalClawbackSmallest: 500,
+    });
+
+    // -- Call #2 --
+    // BEGIN, SELECT (no rows: the previous call moved status to 'cancelled',
+    // which the WHERE clause excludes), COMMIT.
+    queryFn
+      .mockResolvedValueOnce({ rows: [] }) // BEGIN
+      .mockResolvedValueOnce({ rows: [] }) // SELECT — empty
+      .mockResolvedValueOnce({ rows: [] }); // COMMIT
+
+    const second = await reverseReferralsForOrder({
+      orderId: "order-xyz",
+      sellerPubkey: "seller-pk",
+      refundEventRef: "manual:click-2",
+    });
+    expect(second).toEqual({
+      cancelled: 0,
+      refunded: 0,
+      partial: 0,
+      totalClawbackSmallest: 0,
+    });
+
+    // No UPDATE should have been issued in the second pass — only BEGIN +
+    // SELECT + COMMIT (3 of the 7 total queries).
+    const allSql = queryFn.mock.calls.map(
+      (c) => (c[0] as string).split(/\s+/)[0]?.toUpperCase() ?? ""
+    );
+    expect(allSql).toEqual([
+      "BEGIN",
+      "SELECT",
+      "UPDATE",
+      "COMMIT",
+      "BEGIN",
+      "SELECT",
+      "COMMIT",
+    ]);
+
+    expect(releaseFn).toHaveBeenCalledTimes(2);
+  });
+
+  it("a paid row is moved to 'refunded' on the first call and ignored on the second", async () => {
+    queryFn
+      .mockResolvedValueOnce({ rows: [] }) // BEGIN
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            id: 202,
+            status: "paid",
+            rebate_smallest: "1000",
+            refunded_smallest: "0",
+          },
+        ],
+      })
+      .mockResolvedValueOnce({ rows: [] }) // UPDATE -> refunded
+      .mockResolvedValueOnce({ rows: [] }); // COMMIT
+
+    const first = await reverseReferralsForOrder({
+      orderId: "order-paid",
+      sellerPubkey: "seller-pk",
+    });
+    expect(first.refunded).toBe(1);
+    expect(first.totalClawbackSmallest).toBe(1000);
+
+    queryFn
+      .mockResolvedValueOnce({ rows: [] }) // BEGIN
+      .mockResolvedValueOnce({ rows: [] }) // SELECT — empty (already 'refunded')
+      .mockResolvedValueOnce({ rows: [] }); // COMMIT
+    const second = await reverseReferralsForOrder({
+      orderId: "order-paid",
+      sellerPubkey: "seller-pk",
+    });
+    expect(second).toEqual({
+      cancelled: 0,
+      refunded: 0,
+      partial: 0,
+      totalClawbackSmallest: 0,
+    });
+  });
+});

--- a/__tests__/utils/email/unsubscribe-tokens.test.ts
+++ b/__tests__/utils/email/unsubscribe-tokens.test.ts
@@ -1,0 +1,74 @@
+/**
+ * @jest-environment node
+ */
+import {
+  mintAffiliateUnsubscribeToken,
+  verifyAffiliateUnsubscribeToken,
+} from "@/utils/email/unsubscribe-tokens";
+
+const ORIGINAL_SECRET = process.env.AFFILIATE_UNSUBSCRIBE_SECRET;
+
+beforeAll(() => {
+  process.env.AFFILIATE_UNSUBSCRIBE_SECRET =
+    "test-unsubscribe-secret-must-be-at-least-16-chars";
+});
+
+afterAll(() => {
+  if (ORIGINAL_SECRET === undefined) {
+    delete process.env.AFFILIATE_UNSUBSCRIBE_SECRET;
+  } else {
+    process.env.AFFILIATE_UNSUBSCRIBE_SECRET = ORIGINAL_SECRET;
+  }
+});
+
+describe("affiliate unsubscribe tokens", () => {
+  it("round-trips a freshly-minted token", () => {
+    const t = mintAffiliateUnsubscribeToken(42);
+    expect(verifyAffiliateUnsubscribeToken(t)).toEqual({ affiliateId: 42 });
+  });
+
+  it("rejects tokens whose timestamp has been swapped onto another id", () => {
+    const t = mintAffiliateUnsubscribeToken(42, 1_700_000_000_000);
+    // Forge: keep the MAC but replace the id.
+    const [, ts, mac] = t.split(".");
+    const forged = `99.${ts}.${mac}`;
+    expect(verifyAffiliateUnsubscribeToken(forged)).toBeNull();
+  });
+
+  it("rejects tokens older than the 1-year TTL", () => {
+    const oneYearAndOneDay = 366 * 24 * 60 * 60 * 1000;
+    const issued = Date.now() - oneYearAndOneDay;
+    const t = mintAffiliateUnsubscribeToken(42, issued);
+    expect(verifyAffiliateUnsubscribeToken(t)).toBeNull();
+  });
+
+  it("accepts tokens just inside the TTL", () => {
+    const elevenMonths = 11 * 30 * 24 * 60 * 60 * 1000;
+    const issued = Date.now() - elevenMonths;
+    const t = mintAffiliateUnsubscribeToken(42, issued);
+    expect(verifyAffiliateUnsubscribeToken(t)).toEqual({ affiliateId: 42 });
+  });
+
+  it("rejects tokens issued in the implausible future", () => {
+    const t = mintAffiliateUnsubscribeToken(
+      42,
+      Date.now() + 24 * 60 * 60 * 1000
+    );
+    expect(verifyAffiliateUnsubscribeToken(t)).toBeNull();
+  });
+
+  it("rejects tampered MACs", () => {
+    const t = mintAffiliateUnsubscribeToken(42);
+    const tampered = t.slice(0, -1) + (t.endsWith("a") ? "b" : "a");
+    expect(verifyAffiliateUnsubscribeToken(tampered)).toBeNull();
+  });
+
+  it("rejects malformed tokens", () => {
+    expect(verifyAffiliateUnsubscribeToken("")).toBeNull();
+    expect(verifyAffiliateUnsubscribeToken("garbage")).toBeNull();
+    expect(verifyAffiliateUnsubscribeToken("1.2")).toBeNull();
+    expect(
+      verifyAffiliateUnsubscribeToken("not-a-number.123.deadbeef")
+    ).toBeNull();
+  });
+});

--- a/components/cart-invoice-card.tsx
+++ b/components/cart-invoice-card.tsx
@@ -183,9 +183,7 @@ export default function CartInvoiceCard({
             body: JSON.stringify({
               orderId,
               sellerPubkey,
-              affiliateId: aff.affiliateId,
-              affiliateCodeId: aff.codeId,
-              affiliateCode: aff.code,
+              code: aff.code,
               grossSmallest,
               currency: sellerCurrency,
               paymentRail,
@@ -2646,7 +2644,12 @@ export default function CartInvoiceCard({
         }
       });
     }
-    recordAffiliateReferrals(orderId, "stripe").catch(() => {});
+    // NOTE: Stripe referrals are recorded server-side from
+    // /api/stripe/process-transfers (and reversed by the webhook on refund)
+    // so we deliberately do NOT call recordAffiliateReferrals here. Calling
+    // it from the browser would race with the server insert and risk
+    // double-counting toward max_uses, and a buyer who closes the tab
+    // before this fires would lose attribution.
     if (setInvoiceIsPaid) {
       setInvoiceIsPaid(true);
     }

--- a/components/cart-invoice-card.tsx
+++ b/components/cart-invoice-card.tsx
@@ -93,6 +93,7 @@ export default function CartInvoiceCard({
   subtotalCost,
   appliedDiscounts = {},
   discountCodes = {},
+  affiliateMetaBySeller = {},
   shopProfiles,
   onBackToCart,
   setInvoiceIsPaid,
@@ -108,6 +109,15 @@ export default function CartInvoiceCard({
   subtotalCost: number;
   appliedDiscounts?: { [key: string]: number };
   discountCodes?: { [key: string]: string };
+  affiliateMetaBySeller?: {
+    [pubkey: string]: {
+      code: string;
+      codeId: number;
+      affiliateId: number;
+      rebateType: "percent" | "fixed";
+      rebateValue: number;
+    };
+  };
   shopProfiles?: Map<string, ShopProfile>;
   onBackToCart?: () => void;
   setInvoiceIsPaid?: (invoiceIsPaid: boolean) => void;
@@ -133,6 +143,60 @@ export default function CartInvoiceCard({
 
   const { nostr } = useContext(NostrContext);
   const shopContext = useContext(ShopMapContext);
+
+  const recordAffiliateReferrals = async (
+    orderId: string,
+    paymentRail: "stripe" | "lightning" | "cashu"
+  ) => {
+    const entries = Object.entries(affiliateMetaBySeller || {});
+    if (entries.length === 0) return;
+    await Promise.all(
+      entries.map(async ([sellerPubkey, aff]) => {
+        try {
+          const sellerProducts = products.filter(
+            (p) => p.pubkey === sellerPubkey
+          );
+          if (sellerProducts.length === 0) return;
+          const sellerCurrency = (
+            sellerProducts[0]?.currency || "usd"
+          ).toLowerCase();
+          const isZero =
+            isSatsCurrency(sellerCurrency) ||
+            ZERO_DECIMAL_CURRENCIES.has(sellerCurrency);
+          let grossSmallest = 0;
+          for (const p of sellerProducts) {
+            const price =
+              p.bulkPrice !== undefined
+                ? p.bulkPrice
+                : p.weightPrice !== undefined
+                  ? p.weightPrice
+                  : p.volumePrice !== undefined
+                    ? p.volumePrice
+                    : p.price;
+            const qty = quantities[p.id] || 1;
+            const line = price * qty;
+            grossSmallest += isZero ? Math.ceil(line) : Math.ceil(line * 100);
+          }
+          await fetch("/api/affiliates/record-referral", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+              orderId,
+              sellerPubkey,
+              affiliateId: aff.affiliateId,
+              affiliateCodeId: aff.codeId,
+              affiliateCode: aff.code,
+              grossSmallest,
+              currency: sellerCurrency,
+              paymentRail,
+            }),
+          });
+        } catch (e) {
+          console.error("record-referral failed:", e);
+        }
+      })
+    );
+  };
 
   const clearPurchasedFromCart = () => {
     const sfPubkey =
@@ -2160,13 +2224,39 @@ export default function CartInvoiceCard({
                   ? Math.ceil(highestShippingCost)
                   : Math.ceil(highestShippingCost * 100);
               }
+              const aff = affiliateMetaBySeller[pubkey];
+              let affiliateRebateSmallest: number | undefined;
+              if (aff) {
+                if (aff.rebateType === "percent") {
+                  affiliateRebateSmallest = Math.floor(
+                    (sellerSmallest * aff.rebateValue) / 100
+                  );
+                } else {
+                  affiliateRebateSmallest = sellerIsZeroDecimal
+                    ? Math.floor(aff.rebateValue)
+                    : Math.floor(aff.rebateValue * 100);
+                }
+              }
               return {
                 sellerPubkey: pubkey,
                 amountSmallest: sellerSmallest,
                 currency: sellerCurrency,
+                ...(aff
+                  ? {
+                      affiliateId: aff.affiliateId,
+                      affiliateCodeId: aff.codeId,
+                      affiliateCode: aff.code,
+                      affiliateRebateSmallest,
+                    }
+                  : {}),
               };
             })
           : undefined;
+
+        const singleSellerAffiliate =
+          !isMultiMerchant && singleSellerPubkey
+            ? affiliateMetaBySeller[singleSellerPubkey]
+            : undefined;
 
         const response = await fetch("/api/stripe/create-payment-intent", {
           method: "POST",
@@ -2189,6 +2279,20 @@ export default function CartInvoiceCard({
               isCart: "true",
             },
             sellerSplits: sellerSplitsPayload,
+            ...(singleSellerAffiliate
+              ? {
+                  affiliateId: singleSellerAffiliate.affiliateId,
+                  affiliateCodeId: singleSellerAffiliate.codeId,
+                  affiliateCode: singleSellerAffiliate.code,
+                  affiliateRebateSmallest:
+                    singleSellerAffiliate.rebateType === "percent"
+                      ? Math.floor(
+                          (stripeAmount * singleSellerAffiliate.rebateValue) /
+                            100
+                        )
+                      : Math.floor(singleSellerAffiliate.rebateValue * 100),
+                }
+              : {}),
           }),
         });
 
@@ -2542,6 +2646,7 @@ export default function CartInvoiceCard({
         }
       });
     }
+    recordAffiliateReferrals(orderId, "stripe").catch(() => {});
     if (setInvoiceIsPaid) {
       setInvoiceIsPaid(true);
     }
@@ -4556,6 +4661,7 @@ export default function CartInvoiceCard({
       clearPurchasedFromCart();
       setOrderConfirmed(true);
       setPaymentConfirmed(true);
+      recordAffiliateReferrals(uuidv4(), "cashu").catch(() => {});
       if (setCashuPaymentSent) {
         setCashuPaymentSent(true);
       }

--- a/components/my-listings/affiliates.tsx
+++ b/components/my-listings/affiliates.tsx
@@ -20,9 +20,12 @@ import {
   buildAffiliateCodesListProof,
   buildAffiliateCreateProof,
   buildAffiliateDeleteProof,
+  buildAffiliateClickStatsProof,
   buildAffiliateMarkPaidProof,
   buildAffiliatePayoutsListProof,
+  buildAffiliateReverseReferralProof,
   buildAffiliatesListProof,
+  buildAffiliateUpdateProof,
   buildSignedHttpRequestProofTemplate,
   SIGNED_EVENT_HEADER,
 } from "@/utils/nostr/request-auth";
@@ -38,6 +41,10 @@ interface Affiliate {
   lightning_address: string | null;
   stripe_account_id: string | null;
   notes: string | null;
+  payouts_enabled: boolean;
+  payout_failure_count: number;
+  last_payout_failure_at: string | null;
+  last_payout_failure_reason: string | null;
 }
 
 interface AffiliateCode {
@@ -50,7 +57,7 @@ interface AffiliateCode {
   buyer_discount_type: "percent" | "fixed";
   buyer_discount_value: number;
   currency: string | null;
-  payout_schedule: "every_sale" | "daily" | "weekly" | "monthly";
+  payout_schedule: "weekly" | "biweekly" | "monthly";
   expiration: number | null;
   max_uses: number | null;
   times_used: number;
@@ -65,6 +72,23 @@ interface Balance {
   payable_smallest: string;
   paid_smallest: string;
   referral_count: number;
+}
+
+interface ClickStat {
+  affiliate_id: number | null;
+  affiliate_name: string | null;
+  code: string;
+  clicks: number;
+  conversions: number;
+  conversion_rate: number;
+}
+
+interface YtdRow {
+  affiliate_id: number;
+  affiliate_name: string;
+  currency: string;
+  paid_smallest: string;
+  payout_count: number;
 }
 
 interface Payout {
@@ -92,6 +116,9 @@ export default function Affiliates() {
   const [codes, setCodes] = useState<AffiliateCode[]>([]);
   const [balances, setBalances] = useState<Balance[]>([]);
   const [payouts, setPayouts] = useState<Payout[]>([]);
+  const [clickStats, setClickStats] = useState<ClickStat[]>([]);
+  const [ytdRows, setYtdRows] = useState<YtdRow[]>([]);
+  const [reverseOrderId, setReverseOrderId] = useState("");
   const [loading, setLoading] = useState(false);
 
   // New affiliate form
@@ -111,8 +138,8 @@ export default function Affiliates() {
   const [buyerDiscountValue, setBuyerDiscountValue] = useState("0");
   const [codeCurrency, setCodeCurrency] = useState("usd");
   const [payoutSchedule, setPayoutSchedule] = useState<
-    "every_sale" | "daily" | "weekly" | "monthly"
-  >("every_sale");
+    "weekly" | "biweekly" | "monthly"
+  >("monthly");
 
   useEffect(() => {
     if (pubkey && signer) refresh();
@@ -155,12 +182,102 @@ export default function Affiliates() {
         const data = await pRes.json();
         setBalances(data.balances || []);
         setPayouts(data.payouts || []);
+        // YTD totals are derived locally from the same payouts feed so we
+        // don't need a separate endpoint round-trip for the dashboard.
+        setYtdRows(deriveYtdRows(data.payouts || []));
+      }
+
+      // Click analytics — separate endpoint, OK to fail soft.
+      try {
+        const csSigned = await signer.sign(
+          buildSignedHttpRequestProofTemplate(
+            buildAffiliateClickStatsProof(pubkey)
+          )
+        );
+        const csRes = await fetch(
+          `/api/affiliates/click-stats?pubkey=${pubkey}&sinceDays=30`,
+          { headers: { [SIGNED_EVENT_HEADER]: JSON.stringify(csSigned) } }
+        );
+        if (csRes.ok) {
+          const data = await csRes.json();
+          setClickStats(data.stats || []);
+        }
+      } catch (e) {
+        console.warn("click-stats fetch failed:", e);
       }
     } catch (e) {
       console.error("Affiliate refresh failed:", e);
     } finally {
       setLoading(false);
     }
+  }
+
+  function deriveYtdRows(allPayouts: Payout[]): YtdRow[] {
+    const startOfYear = new Date(new Date().getFullYear(), 0, 1).getTime();
+    const acc = new Map<string, YtdRow>();
+    for (const p of allPayouts) {
+      if (p.status !== "paid") continue;
+      if (new Date(p.paid_at).getTime() < startOfYear) continue;
+      const key = `${p.affiliate_id}:${p.currency}`;
+      const prev = acc.get(key);
+      const amt = Number(p.amount_smallest);
+      if (prev) {
+        prev.paid_smallest = String(Number(prev.paid_smallest) + amt);
+        prev.payout_count += 1;
+      } else {
+        acc.set(key, {
+          affiliate_id: p.affiliate_id,
+          affiliate_name: p.affiliate_name,
+          currency: p.currency,
+          paid_smallest: String(amt),
+          payout_count: 1,
+        });
+      }
+    }
+    return Array.from(acc.values()).sort(
+      (a, b) => Number(b.paid_smallest) - Number(a.paid_smallest)
+    );
+  }
+
+  async function reverseReferralByOrder() {
+    if (!pubkey || !signer) return;
+    const orderId = reverseOrderId.trim();
+    if (!orderId) return;
+    if (
+      !window.confirm(
+        `Reverse all affiliate referrals for order "${orderId}"? Pending rebates will be cancelled and already-paid rebates flagged for clawback.`
+      )
+    ) {
+      return;
+    }
+    const signedEvent = await signer.sign(
+      buildSignedHttpRequestProofTemplate(
+        buildAffiliateReverseReferralProof({
+          pubkey,
+          orderId,
+          sellerPubkey: pubkey,
+        })
+      )
+    );
+    const res = await fetch("/api/affiliates/reverse-referral", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        [SIGNED_EVENT_HEADER]: JSON.stringify(signedEvent),
+      },
+      body: JSON.stringify({
+        pubkey,
+        orderId,
+        sellerPubkey: pubkey,
+      }),
+    });
+    if (!res.ok) {
+      const j = await res.json().catch(() => ({}));
+      alert(`Reverse failed: ${j.error || res.status}`);
+      return;
+    }
+    setReverseOrderId("");
+    await refresh();
   }
 
   async function createAffiliate() {
@@ -195,21 +312,89 @@ export default function Affiliates() {
     }
   }
 
-  async function deleteAffiliate(id: number) {
+  async function deleteAffiliate(id: number, force = false) {
     if (!pubkey || !signer) return;
     const signedEvent = await signer.sign(
       buildSignedHttpRequestProofTemplate(
         buildAffiliateDeleteProof({ pubkey, affiliateId: id })
       )
     );
-    await fetch("/api/affiliates/manage", {
+    const res = await fetch("/api/affiliates/manage", {
       method: "DELETE",
       headers: {
         "Content-Type": "application/json",
         [SIGNED_EVENT_HEADER]: JSON.stringify(signedEvent),
       },
-      body: JSON.stringify({ pubkey, affiliateId: id }),
+      body: JSON.stringify({ pubkey, affiliateId: id, force }),
     });
+    if (res.status === 409) {
+      const j = await res.json().catch(() => ({}));
+      const ok = window.confirm(
+        `${j.error || "Affiliate has unsettled balance."}\n\nForce delete and cancel pending referrals?`
+      );
+      if (ok) await deleteAffiliate(id, true);
+      return;
+    }
+    await refresh();
+  }
+
+  async function regenerateInviteToken(id: number) {
+    if (!pubkey || !signer) return;
+    if (
+      !window.confirm(
+        "Generate a new invite link? The old link will stop working immediately."
+      )
+    ) {
+      return;
+    }
+    const signedEvent = await signer.sign(
+      buildSignedHttpRequestProofTemplate(
+        buildAffiliateUpdateProof({ pubkey, affiliateId: id })
+      )
+    );
+    const res = await fetch("/api/affiliates/manage", {
+      method: "PUT",
+      headers: {
+        "Content-Type": "application/json",
+        [SIGNED_EVENT_HEADER]: JSON.stringify(signedEvent),
+      },
+      body: JSON.stringify({
+        pubkey,
+        affiliateId: id,
+        action: "regenerate-invite-token",
+      }),
+    });
+    if (!res.ok) {
+      alert("Failed to regenerate invite link");
+      return;
+    }
+    await refresh();
+  }
+
+  async function setPayoutsEnabled(id: number, enabled: boolean) {
+    if (!pubkey || !signer) return;
+    const signedEvent = await signer.sign(
+      buildSignedHttpRequestProofTemplate(
+        buildAffiliateUpdateProof({ pubkey, affiliateId: id })
+      )
+    );
+    const res = await fetch("/api/affiliates/manage", {
+      method: "PUT",
+      headers: {
+        "Content-Type": "application/json",
+        [SIGNED_EVENT_HEADER]: JSON.stringify(signedEvent),
+      },
+      body: JSON.stringify({
+        pubkey,
+        affiliateId: id,
+        action: "set-payouts-enabled",
+        enabled,
+      }),
+    });
+    if (!res.ok) {
+      alert("Failed to toggle payouts");
+      return;
+    }
     await refresh();
   }
 
@@ -381,7 +566,7 @@ export default function Affiliates() {
                     <CardBody>
                       <div className="flex items-start justify-between gap-4">
                         <div className="flex-1 space-y-1">
-                          <div className="flex items-center gap-2">
+                          <div className="flex flex-wrap items-center gap-2">
                             <span className="text-lg font-semibold text-black">
                               {a.name}
                             </span>
@@ -394,7 +579,17 @@ export default function Affiliates() {
                                 Invite pending
                               </Chip>
                             )}
+                            {a.payouts_enabled === false && (
+                              <Chip color="danger" size="sm">
+                                Payouts disabled
+                              </Chip>
+                            )}
                           </div>
+                          {a.last_payout_failure_reason && (
+                            <p className="text-xs text-red-600">
+                              Last payout error: {a.last_payout_failure_reason}
+                            </p>
+                          )}
                           {a.email && (
                             <p className="text-xs text-gray-500">{a.email}</p>
                           )}
@@ -423,6 +618,34 @@ export default function Affiliates() {
                             >
                               <ClipboardDocumentIcon className="h-4 w-4" />
                             </Button>
+                          </div>
+                          <div className="mt-2 flex flex-wrap gap-2">
+                            <Button
+                              size="sm"
+                              variant="bordered"
+                              className="text-black"
+                              onClick={() => regenerateInviteToken(a.id)}
+                            >
+                              Regenerate invite link
+                            </Button>
+                            {a.payouts_enabled === false ? (
+                              <Button
+                                size="sm"
+                                color="primary"
+                                onClick={() => setPayoutsEnabled(a.id, true)}
+                              >
+                                Re-enable payouts
+                              </Button>
+                            ) : (
+                              <Button
+                                size="sm"
+                                variant="bordered"
+                                className="text-black"
+                                onClick={() => setPayoutsEnabled(a.id, false)}
+                              >
+                                Pause payouts
+                              </Button>
+                            )}
                           </div>
                         </div>
                         <ConfirmActionDropdown
@@ -525,18 +748,13 @@ export default function Affiliates() {
                     selectedKeys={[payoutSchedule]}
                     onChange={(e) =>
                       setPayoutSchedule(
-                        e.target.value as
-                          | "every_sale"
-                          | "daily"
-                          | "weekly"
-                          | "monthly"
+                        e.target.value as "weekly" | "biweekly" | "monthly"
                       )
                     }
                   >
-                    <SelectItem key="every_sale">Every sale</SelectItem>
-                    <SelectItem key="daily">Daily</SelectItem>
                     <SelectItem key="weekly">Weekly</SelectItem>
-                    <SelectItem key="monthly">Monthly</SelectItem>
+                    <SelectItem key="biweekly">Biweekly</SelectItem>
+                    <SelectItem key="monthly">Monthly (default)</SelectItem>
                   </Select>
                 </div>
                 <Button
@@ -686,6 +904,129 @@ export default function Affiliates() {
                 </Card>
               ))
             )}
+          </div>
+        </Tab>
+
+        <Tab key="analytics" title="Analytics">
+          <div className="space-y-4">
+            <Card className="bg-white">
+              <CardHeader className="font-semibold text-black">
+                Clicks &amp; conversions (last 30 days)
+              </CardHeader>
+              <CardBody>
+                {clickStats.length === 0 ? (
+                  <p className="text-sm text-gray-500">
+                    No tracked clicks yet. Once buyers visit a{" "}
+                    <code>?ref=CODE</code> link the data will appear here.
+                  </p>
+                ) : (
+                  <div className="overflow-x-auto">
+                    <table className="w-full text-sm">
+                      <thead className="text-left text-gray-500">
+                        <tr>
+                          <th className="py-1 pr-3">Code</th>
+                          <th className="py-1 pr-3">Affiliate</th>
+                          <th className="py-1 pr-3 text-right">Clicks</th>
+                          <th className="py-1 pr-3 text-right">Conversions</th>
+                          <th className="py-1 pr-3 text-right">Rate</th>
+                        </tr>
+                      </thead>
+                      <tbody className="text-black">
+                        {clickStats.map((s) => (
+                          <tr key={`${s.code}-${s.affiliate_id ?? "x"}`}>
+                            <td className="py-1 pr-3 font-mono">{s.code}</td>
+                            <td className="py-1 pr-3">
+                              {s.affiliate_name ?? (
+                                <span className="text-gray-400">
+                                  (no matching code)
+                                </span>
+                              )}
+                            </td>
+                            <td className="py-1 pr-3 text-right">{s.clicks}</td>
+                            <td className="py-1 pr-3 text-right">
+                              {s.conversions}
+                            </td>
+                            <td className="py-1 pr-3 text-right">
+                              {(s.conversion_rate * 100).toFixed(1)}%
+                            </td>
+                          </tr>
+                        ))}
+                      </tbody>
+                    </table>
+                  </div>
+                )}
+              </CardBody>
+            </Card>
+
+            <Card className="bg-white">
+              <CardHeader className="font-semibold text-black">
+                Year-to-date paid out
+              </CardHeader>
+              <CardBody>
+                {ytdRows.length === 0 ? (
+                  <p className="text-sm text-gray-500">
+                    No payouts so far this year.
+                  </p>
+                ) : (
+                  <div className="overflow-x-auto">
+                    <table className="w-full text-sm">
+                      <thead className="text-left text-gray-500">
+                        <tr>
+                          <th className="py-1 pr-3">Affiliate</th>
+                          <th className="py-1 pr-3">Currency</th>
+                          <th className="py-1 pr-3 text-right">Paid</th>
+                          <th className="py-1 pr-3 text-right">Payouts</th>
+                        </tr>
+                      </thead>
+                      <tbody className="text-black">
+                        {ytdRows.map((r) => (
+                          <tr key={`${r.affiliate_id}-${r.currency}`}>
+                            <td className="py-1 pr-3">{r.affiliate_name}</td>
+                            <td className="py-1 pr-3 uppercase">
+                              {r.currency}
+                            </td>
+                            <td className="py-1 pr-3 text-right">
+                              {formatAmount(r.paid_smallest, r.currency)}
+                            </td>
+                            <td className="py-1 pr-3 text-right">
+                              {r.payout_count}
+                            </td>
+                          </tr>
+                        ))}
+                      </tbody>
+                    </table>
+                  </div>
+                )}
+              </CardBody>
+            </Card>
+
+            <Card className="bg-white">
+              <CardHeader className="font-semibold text-black">
+                Reverse a referral (Lightning / Cashu refunds)
+              </CardHeader>
+              <CardBody className="space-y-2">
+                <p className="text-xs text-gray-500">
+                  Stripe refunds reverse referrals automatically. For Lightning
+                  or Cashu refunds, paste the order ID here to cancel pending
+                  rebates and flag any already-paid rebates for clawback.
+                </p>
+                <div className="flex gap-2">
+                  <Input
+                    aria-label="Order ID"
+                    placeholder="order_… or invoice ID"
+                    value={reverseOrderId}
+                    onValueChange={setReverseOrderId}
+                  />
+                  <Button
+                    className={BLUEBUTTONCLASSNAMES}
+                    isDisabled={!reverseOrderId.trim()}
+                    onClick={reverseReferralByOrder}
+                  >
+                    Reverse
+                  </Button>
+                </div>
+              </CardBody>
+            </Card>
           </div>
         </Tab>
       </Tabs>

--- a/components/my-listings/affiliates.tsx
+++ b/components/my-listings/affiliates.tsx
@@ -1,0 +1,694 @@
+import { useContext, useEffect, useState } from "react";
+import {
+  Button,
+  Input,
+  Card,
+  CardBody,
+  CardHeader,
+  Chip,
+  Select,
+  SelectItem,
+  Tabs,
+  Tab,
+} from "@heroui/react";
+import { TrashIcon, ClipboardDocumentIcon } from "@heroicons/react/24/outline";
+import { BLUEBUTTONCLASSNAMES } from "@/utils/STATIC-VARIABLES";
+import { SignerContext } from "@/components/utility-components/nostr-context-provider";
+import {
+  buildAffiliateCodeCreateProof,
+  buildAffiliateCodeDeleteProof,
+  buildAffiliateCodesListProof,
+  buildAffiliateCreateProof,
+  buildAffiliateDeleteProof,
+  buildAffiliateMarkPaidProof,
+  buildAffiliatePayoutsListProof,
+  buildAffiliatesListProof,
+  buildSignedHttpRequestProofTemplate,
+  SIGNED_EVENT_HEADER,
+} from "@/utils/nostr/request-auth";
+import ConfirmActionDropdown from "../utility-components/dropdowns/confirm-action-dropdown";
+
+interface Affiliate {
+  id: number;
+  name: string;
+  email: string | null;
+  affiliate_pubkey: string | null;
+  invite_token: string;
+  invite_claimed_at: string | null;
+  lightning_address: string | null;
+  stripe_account_id: string | null;
+  notes: string | null;
+}
+
+interface AffiliateCode {
+  id: number;
+  affiliate_id: number;
+  affiliate_name?: string;
+  code: string;
+  rebate_type: "percent" | "fixed";
+  rebate_value: number;
+  buyer_discount_type: "percent" | "fixed";
+  buyer_discount_value: number;
+  currency: string | null;
+  payout_schedule: "every_sale" | "daily" | "weekly" | "monthly";
+  expiration: number | null;
+  max_uses: number | null;
+  times_used: number;
+  is_active: boolean;
+}
+
+interface Balance {
+  affiliate_id: number;
+  affiliate_name: string;
+  currency: string;
+  pending_smallest: string;
+  payable_smallest: string;
+  paid_smallest: string;
+  referral_count: number;
+}
+
+interface Payout {
+  id: number;
+  affiliate_id: number;
+  affiliate_name: string;
+  method: string;
+  amount_smallest: string;
+  currency: string;
+  external_ref: string | null;
+  note: string | null;
+  status: string;
+  paid_at: string;
+}
+
+function formatAmount(smallest: string | number, currency: string) {
+  const n = typeof smallest === "string" ? Number(smallest) : smallest;
+  if (currency.toLowerCase() === "sats") return `${n} sats`;
+  return `${(n / 100).toFixed(2)} ${currency.toUpperCase()}`;
+}
+
+export default function Affiliates() {
+  const { pubkey, signer } = useContext(SignerContext);
+  const [affiliates, setAffiliates] = useState<Affiliate[]>([]);
+  const [codes, setCodes] = useState<AffiliateCode[]>([]);
+  const [balances, setBalances] = useState<Balance[]>([]);
+  const [payouts, setPayouts] = useState<Payout[]>([]);
+  const [loading, setLoading] = useState(false);
+
+  // New affiliate form
+  const [newName, setNewName] = useState("");
+  const [newEmail, setNewEmail] = useState("");
+  const [newLightning, setNewLightning] = useState("");
+  const [newStripeAcct, setNewStripeAcct] = useState("");
+
+  // New code form
+  const [codeAffiliateId, setCodeAffiliateId] = useState<string>("");
+  const [codeText, setCodeText] = useState("");
+  const [rebateType, setRebateType] = useState<"percent" | "fixed">("percent");
+  const [rebateValue, setRebateValue] = useState("");
+  const [buyerDiscountType, setBuyerDiscountType] = useState<
+    "percent" | "fixed"
+  >("percent");
+  const [buyerDiscountValue, setBuyerDiscountValue] = useState("0");
+  const [codeCurrency, setCodeCurrency] = useState("usd");
+  const [payoutSchedule, setPayoutSchedule] = useState<
+    "every_sale" | "daily" | "weekly" | "monthly"
+  >("every_sale");
+
+  useEffect(() => {
+    if (pubkey && signer) refresh();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [pubkey, signer]);
+
+  async function refresh() {
+    if (!pubkey || !signer) return;
+    setLoading(true);
+    try {
+      const [aSigned, cSigned, pSigned] = await Promise.all([
+        signer.sign(
+          buildSignedHttpRequestProofTemplate(buildAffiliatesListProof(pubkey))
+        ),
+        signer.sign(
+          buildSignedHttpRequestProofTemplate(
+            buildAffiliateCodesListProof(pubkey)
+          )
+        ),
+        signer.sign(
+          buildSignedHttpRequestProofTemplate(
+            buildAffiliatePayoutsListProof(pubkey)
+          )
+        ),
+      ]);
+      const [aRes, cRes, pRes] = await Promise.all([
+        fetch(`/api/affiliates/manage?pubkey=${pubkey}`, {
+          headers: { [SIGNED_EVENT_HEADER]: JSON.stringify(aSigned) },
+        }),
+        fetch(`/api/affiliates/codes?pubkey=${pubkey}`, {
+          headers: { [SIGNED_EVENT_HEADER]: JSON.stringify(cSigned) },
+        }),
+        fetch(`/api/affiliates/payouts?pubkey=${pubkey}`, {
+          headers: { [SIGNED_EVENT_HEADER]: JSON.stringify(pSigned) },
+        }),
+      ]);
+      if (aRes.ok) setAffiliates(await aRes.json());
+      if (cRes.ok) setCodes(await cRes.json());
+      if (pRes.ok) {
+        const data = await pRes.json();
+        setBalances(data.balances || []);
+        setPayouts(data.payouts || []);
+      }
+    } catch (e) {
+      console.error("Affiliate refresh failed:", e);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  async function createAffiliate() {
+    if (!pubkey || !signer || !newName) return;
+    const signedEvent = await signer.sign(
+      buildSignedHttpRequestProofTemplate(
+        buildAffiliateCreateProof({ pubkey, name: newName })
+      )
+    );
+    const res = await fetch("/api/affiliates/manage", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        [SIGNED_EVENT_HEADER]: JSON.stringify(signedEvent),
+      },
+      body: JSON.stringify({
+        pubkey,
+        name: newName,
+        email: newEmail || null,
+        lightningAddress: newLightning || null,
+        stripeAccountId: newStripeAcct || null,
+      }),
+    });
+    if (res.ok) {
+      setNewName("");
+      setNewEmail("");
+      setNewLightning("");
+      setNewStripeAcct("");
+      await refresh();
+    } else {
+      alert("Failed to create affiliate");
+    }
+  }
+
+  async function deleteAffiliate(id: number) {
+    if (!pubkey || !signer) return;
+    const signedEvent = await signer.sign(
+      buildSignedHttpRequestProofTemplate(
+        buildAffiliateDeleteProof({ pubkey, affiliateId: id })
+      )
+    );
+    await fetch("/api/affiliates/manage", {
+      method: "DELETE",
+      headers: {
+        "Content-Type": "application/json",
+        [SIGNED_EVENT_HEADER]: JSON.stringify(signedEvent),
+      },
+      body: JSON.stringify({ pubkey, affiliateId: id }),
+    });
+    await refresh();
+  }
+
+  async function createCode() {
+    if (!pubkey || !signer || !codeAffiliateId || !codeText || !rebateValue)
+      return;
+    const normalized = codeText.trim().toUpperCase();
+    const signedEvent = await signer.sign(
+      buildSignedHttpRequestProofTemplate(
+        buildAffiliateCodeCreateProof({
+          pubkey,
+          affiliateId: Number(codeAffiliateId),
+          code: normalized,
+        })
+      )
+    );
+    const res = await fetch("/api/affiliates/codes", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        [SIGNED_EVENT_HEADER]: JSON.stringify(signedEvent),
+      },
+      body: JSON.stringify({
+        pubkey,
+        affiliateId: Number(codeAffiliateId),
+        code: normalized,
+        rebateType,
+        rebateValue: Number(rebateValue),
+        buyerDiscountType,
+        buyerDiscountValue: Number(buyerDiscountValue || 0),
+        currency: codeCurrency,
+        payoutSchedule,
+      }),
+    });
+    if (res.ok) {
+      setCodeText("");
+      setRebateValue("");
+      setBuyerDiscountValue("0");
+      await refresh();
+    } else {
+      alert("Failed to create code");
+    }
+  }
+
+  async function deleteCode(id: number) {
+    if (!pubkey || !signer) return;
+    const signedEvent = await signer.sign(
+      buildSignedHttpRequestProofTemplate(
+        buildAffiliateCodeDeleteProof({ pubkey, codeId: id })
+      )
+    );
+    await fetch("/api/affiliates/codes", {
+      method: "DELETE",
+      headers: {
+        "Content-Type": "application/json",
+        [SIGNED_EVENT_HEADER]: JSON.stringify(signedEvent),
+      },
+      body: JSON.stringify({ pubkey, codeId: id }),
+    });
+    await refresh();
+  }
+
+  async function markPaid(b: Balance) {
+    if (!pubkey || !signer) return;
+    const amount = Number(b.payable_smallest);
+    if (amount <= 0) {
+      alert("No payable balance");
+      return;
+    }
+    const signedEvent = await signer.sign(
+      buildSignedHttpRequestProofTemplate(
+        buildAffiliateMarkPaidProof({
+          pubkey,
+          affiliateId: b.affiliate_id,
+          amountSmallest: amount,
+          currency: b.currency,
+        })
+      )
+    );
+    const res = await fetch("/api/affiliates/mark-paid", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        [SIGNED_EVENT_HEADER]: JSON.stringify(signedEvent),
+      },
+      body: JSON.stringify({
+        pubkey,
+        affiliateId: b.affiliate_id,
+        amountSmallest: amount,
+        currency: b.currency,
+        note: "Manual settlement",
+      }),
+    });
+    if (res.ok) {
+      await refresh();
+    } else {
+      const j = await res.json().catch(() => ({}));
+      alert(j.error || "Failed to mark paid");
+    }
+  }
+
+  function copy(text: string) {
+    navigator.clipboard.writeText(text).catch(() => {});
+  }
+
+  return (
+    <div className="w-full space-y-6 p-4">
+      <div className="mb-2">
+        <h2 className="mb-2 text-2xl font-bold text-black">Affiliates</h2>
+        <p className="text-sm text-gray-600">
+          Invite affiliates, give them codes, and track rebates. Codes work for
+          both Stripe and Bitcoin orders. Buyers can apply a code via the
+          checkout field or the link <code>?ref=CODE</code>.
+        </p>
+      </div>
+
+      <Tabs aria-label="Affiliate tabs" className="text-black">
+        <Tab key="affiliates" title="Affiliates">
+          <div className="space-y-4">
+            <Card className="bg-white">
+              <CardHeader>
+                <h3 className="text-lg font-semibold text-black">
+                  Add affiliate
+                </h3>
+              </CardHeader>
+              <CardBody className="space-y-3">
+                <Input
+                  label="Name"
+                  value={newName}
+                  onChange={(e) => setNewName(e.target.value)}
+                />
+                <Input
+                  label="Email (optional)"
+                  value={newEmail}
+                  onChange={(e) => setNewEmail(e.target.value)}
+                />
+                <Input
+                  label="Lightning address (optional)"
+                  placeholder="alice@getalby.com"
+                  value={newLightning}
+                  onChange={(e) => setNewLightning(e.target.value)}
+                />
+                <Input
+                  label="Stripe Connect account id (optional)"
+                  placeholder="acct_..."
+                  value={newStripeAcct}
+                  onChange={(e) => setNewStripeAcct(e.target.value)}
+                />
+                <Button
+                  className={BLUEBUTTONCLASSNAMES}
+                  onClick={createAffiliate}
+                  isDisabled={!newName}
+                >
+                  Add affiliate
+                </Button>
+              </CardBody>
+            </Card>
+
+            {loading ? (
+              <p className="text-black">Loading...</p>
+            ) : (
+              affiliates.map((a) => {
+                const inviteUrl =
+                  typeof window !== "undefined"
+                    ? `${window.location.origin}/affiliate/${a.invite_token}`
+                    : `/affiliate/${a.invite_token}`;
+                return (
+                  <Card key={a.id} className="bg-white">
+                    <CardBody>
+                      <div className="flex items-start justify-between gap-4">
+                        <div className="flex-1 space-y-1">
+                          <div className="flex items-center gap-2">
+                            <span className="text-lg font-semibold text-black">
+                              {a.name}
+                            </span>
+                            {a.invite_claimed_at ? (
+                              <Chip color="success" size="sm">
+                                Claimed
+                              </Chip>
+                            ) : (
+                              <Chip color="warning" size="sm">
+                                Invite pending
+                              </Chip>
+                            )}
+                          </div>
+                          {a.email && (
+                            <p className="text-xs text-gray-500">{a.email}</p>
+                          )}
+                          {a.lightning_address && (
+                            <p className="text-xs text-gray-500">
+                              ⚡ {a.lightning_address}
+                            </p>
+                          )}
+                          {a.stripe_account_id && (
+                            <p className="text-xs text-gray-500">
+                              Stripe: {a.stripe_account_id}
+                            </p>
+                          )}
+                          <div className="mt-2 flex items-center gap-2">
+                            <Input
+                              size="sm"
+                              value={inviteUrl}
+                              readOnly
+                              className="text-black"
+                            />
+                            <Button
+                              isIconOnly
+                              size="sm"
+                              variant="light"
+                              onClick={() => copy(inviteUrl)}
+                            >
+                              <ClipboardDocumentIcon className="h-4 w-4" />
+                            </Button>
+                          </div>
+                        </div>
+                        <ConfirmActionDropdown
+                          helpText="Delete this affiliate? Their codes and referral history will also be removed."
+                          buttonLabel="Delete"
+                          onConfirm={() => deleteAffiliate(a.id)}
+                        >
+                          <Button
+                            isIconOnly
+                            color="danger"
+                            variant="light"
+                            size="sm"
+                          >
+                            <TrashIcon className="h-5 w-5" />
+                          </Button>
+                        </ConfirmActionDropdown>
+                      </div>
+                    </CardBody>
+                  </Card>
+                );
+              })
+            )}
+          </div>
+        </Tab>
+
+        <Tab key="codes" title="Codes">
+          <div className="space-y-4">
+            <Card className="bg-white">
+              <CardHeader>
+                <h3 className="text-lg font-semibold text-black">Add code</h3>
+              </CardHeader>
+              <CardBody className="space-y-3">
+                <Select
+                  label="Affiliate"
+                  selectedKeys={codeAffiliateId ? [codeAffiliateId] : []}
+                  onChange={(e) => setCodeAffiliateId(e.target.value)}
+                >
+                  {affiliates.map((a) => (
+                    <SelectItem key={String(a.id)}>{a.name}</SelectItem>
+                  ))}
+                </Select>
+                <Input
+                  label="Code"
+                  placeholder="ALICE10"
+                  value={codeText}
+                  onChange={(e) => setCodeText(e.target.value.toUpperCase())}
+                />
+                <div className="grid grid-cols-2 gap-3">
+                  <Select
+                    label="Rebate type"
+                    selectedKeys={[rebateType]}
+                    onChange={(e) =>
+                      setRebateType(e.target.value as "percent" | "fixed")
+                    }
+                  >
+                    <SelectItem key="percent">Percent</SelectItem>
+                    <SelectItem key="fixed">Fixed</SelectItem>
+                  </Select>
+                  <Input
+                    label={`Rebate value (${
+                      rebateType === "percent" ? "%" : "amount"
+                    })`}
+                    type="number"
+                    value={rebateValue}
+                    onChange={(e) => setRebateValue(e.target.value)}
+                  />
+                </div>
+                <div className="grid grid-cols-2 gap-3">
+                  <Select
+                    label="Buyer discount type"
+                    selectedKeys={[buyerDiscountType]}
+                    onChange={(e) =>
+                      setBuyerDiscountType(
+                        e.target.value as "percent" | "fixed"
+                      )
+                    }
+                  >
+                    <SelectItem key="percent">Percent</SelectItem>
+                    <SelectItem key="fixed">Fixed</SelectItem>
+                  </Select>
+                  <Input
+                    label={`Buyer discount (${
+                      buyerDiscountType === "percent" ? "%" : "amount"
+                    })`}
+                    type="number"
+                    value={buyerDiscountValue}
+                    onChange={(e) => setBuyerDiscountValue(e.target.value)}
+                  />
+                </div>
+                <div className="grid grid-cols-2 gap-3">
+                  <Input
+                    label="Currency"
+                    value={codeCurrency}
+                    onChange={(e) =>
+                      setCodeCurrency(e.target.value.toLowerCase())
+                    }
+                  />
+                  <Select
+                    label="Payout schedule"
+                    selectedKeys={[payoutSchedule]}
+                    onChange={(e) =>
+                      setPayoutSchedule(
+                        e.target.value as
+                          | "every_sale"
+                          | "daily"
+                          | "weekly"
+                          | "monthly"
+                      )
+                    }
+                  >
+                    <SelectItem key="every_sale">Every sale</SelectItem>
+                    <SelectItem key="daily">Daily</SelectItem>
+                    <SelectItem key="weekly">Weekly</SelectItem>
+                    <SelectItem key="monthly">Monthly</SelectItem>
+                  </Select>
+                </div>
+                <Button
+                  className={BLUEBUTTONCLASSNAMES}
+                  onClick={createCode}
+                  isDisabled={!codeAffiliateId || !codeText || !rebateValue}
+                >
+                  Add code
+                </Button>
+              </CardBody>
+            </Card>
+
+            {codes.map((c) => (
+              <Card key={c.id} className="bg-white">
+                <CardBody>
+                  <div className="flex items-start justify-between gap-4">
+                    <div className="flex-1">
+                      <div className="flex items-center gap-2">
+                        <span className="font-mono text-lg font-bold text-black">
+                          {c.code}
+                        </span>
+                        <Chip size="sm" color="primary">
+                          {c.affiliate_name}
+                        </Chip>
+                        {!c.is_active && (
+                          <Chip size="sm" color="default">
+                            Inactive
+                          </Chip>
+                        )}
+                      </div>
+                      <p className="text-sm text-black">
+                        Rebate:{" "}
+                        {c.rebate_type === "percent"
+                          ? `${c.rebate_value}%`
+                          : `${c.rebate_value} ${(c.currency || "").toUpperCase()}`}{" "}
+                        · Buyer discount:{" "}
+                        {c.buyer_discount_type === "percent"
+                          ? `${c.buyer_discount_value}%`
+                          : `${c.buyer_discount_value} ${(
+                              c.currency || ""
+                            ).toUpperCase()}`}
+                      </p>
+                      <p className="text-xs text-gray-500">
+                        Schedule: {c.payout_schedule.replace("_", " ")} · Used:{" "}
+                        {c.times_used}
+                        {c.max_uses ? ` / ${c.max_uses}` : ""}
+                      </p>
+                    </div>
+                    <ConfirmActionDropdown
+                      helpText="Delete this code? Existing referral history is preserved but new orders cannot use it."
+                      buttonLabel="Delete"
+                      onConfirm={() => deleteCode(c.id)}
+                    >
+                      <Button
+                        isIconOnly
+                        color="danger"
+                        variant="light"
+                        size="sm"
+                      >
+                        <TrashIcon className="h-5 w-5" />
+                      </Button>
+                    </ConfirmActionDropdown>
+                  </div>
+                </CardBody>
+              </Card>
+            ))}
+          </div>
+        </Tab>
+
+        <Tab key="balances" title="Balances">
+          <div className="space-y-3">
+            {balances.length === 0 ? (
+              <p className="text-gray-500">No referrals yet.</p>
+            ) : (
+              balances.map((b) => (
+                <Card
+                  key={`${b.affiliate_id}-${b.currency}`}
+                  className="bg-white"
+                >
+                  <CardBody>
+                    <div className="flex items-center justify-between">
+                      <div>
+                        <p className="text-lg font-semibold text-black">
+                          {b.affiliate_name}{" "}
+                          <span className="text-sm text-gray-500">
+                            ({b.currency.toUpperCase()})
+                          </span>
+                        </p>
+                        <p className="text-sm text-black">
+                          Pending:{" "}
+                          {formatAmount(b.pending_smallest, b.currency)} ·
+                          Payable now:{" "}
+                          {formatAmount(b.payable_smallest, b.currency)} ·
+                          Lifetime paid:{" "}
+                          {formatAmount(b.paid_smallest, b.currency)}
+                        </p>
+                        <p className="text-xs text-gray-500">
+                          {b.referral_count} referrals
+                        </p>
+                      </div>
+                      <Button
+                        className={BLUEBUTTONCLASSNAMES}
+                        size="sm"
+                        onClick={() => markPaid(b)}
+                        isDisabled={Number(b.payable_smallest) <= 0}
+                      >
+                        Mark paid
+                      </Button>
+                    </div>
+                  </CardBody>
+                </Card>
+              ))
+            )}
+          </div>
+        </Tab>
+
+        <Tab key="payouts" title="Payouts">
+          <div className="space-y-3">
+            {payouts.length === 0 ? (
+              <p className="text-gray-500">No payouts recorded yet.</p>
+            ) : (
+              payouts.map((p) => (
+                <Card key={p.id} className="bg-white">
+                  <CardBody>
+                    <div className="flex items-center justify-between">
+                      <div>
+                        <p className="font-semibold text-black">
+                          {p.affiliate_name} ·{" "}
+                          {formatAmount(p.amount_smallest, p.currency)}
+                        </p>
+                        <p className="text-xs text-gray-500">
+                          {p.method} · {new Date(p.paid_at).toLocaleString()}
+                          {p.external_ref ? ` · ${p.external_ref}` : ""}
+                        </p>
+                        {p.note && (
+                          <p className="text-xs text-gray-500">{p.note}</p>
+                        )}
+                      </div>
+                      <Chip
+                        size="sm"
+                        color={p.status === "paid" ? "success" : "danger"}
+                      >
+                        {p.status}
+                      </Chip>
+                    </div>
+                  </CardBody>
+                </Card>
+              ))
+            )}
+          </div>
+        </Tab>
+      </Tabs>
+    </div>
+  );
+}

--- a/components/my-listings/my-listings.tsx
+++ b/components/my-listings/my-listings.tsx
@@ -12,6 +12,7 @@ import { ShopMapContext } from "@/utils/context/context";
 import { ShopProfile } from "../../utils/types/types";
 import { sanitizeUrl } from "@braintree/sanitize-url";
 import DiscountCodes from "./discount-codes";
+import Affiliates from "./affiliates";
 import StripeConnectBanner from "@/components/stripe-connect/StripeConnectBanner";
 
 const MyListingsPage = () => {
@@ -102,6 +103,15 @@ const MyListingsPage = () => {
         <Button
           className="w-full bg-transparent px-4 py-2 text-left text-sm font-bold text-black hover:bg-gray-100"
           onClick={() => {
+            setSelectedSection("Affiliates");
+            setIsMobileMenuOpen(false);
+          }}
+        >
+          Affiliates
+        </Button>
+        <Button
+          className="w-full bg-transparent px-4 py-2 text-left text-sm font-bold text-black hover:bg-gray-100"
+          onClick={() => {
             handleViewOrders();
             setIsMobileMenuOpen(false);
           }}
@@ -175,6 +185,16 @@ const MyListingsPage = () => {
                 Discounts
               </Button>
               <Button
+                className={`bg-transparent px-0 text-lg font-bold ${
+                  selectedSection === "Affiliates"
+                    ? "border-b-4 border-black text-black"
+                    : "text-gray-500 hover:text-black"
+                }`}
+                onClick={() => setSelectedSection("Affiliates")}
+              >
+                Affiliates
+              </Button>
+              <Button
                 className="bg-transparent px-0 text-lg font-bold text-gray-500 hover:text-black"
                 onClick={() => handleViewOrders()}
               >
@@ -239,6 +259,7 @@ const MyListingsPage = () => {
             )}
           </div>
           {usersPubkey && selectedSection === "Discounts" && <DiscountCodes />}
+          {usersPubkey && selectedSection === "Affiliates" && <Affiliates />}
         </div>
       </div>
       <SignInModal isOpen={isOpen} onClose={onClose} />

--- a/components/utility-components/affiliate-ref-tracker.tsx
+++ b/components/utility-components/affiliate-ref-tracker.tsx
@@ -1,0 +1,37 @@
+import { useEffect } from "react";
+import { useRouter } from "next/router";
+
+const COOKIE_NAME = "mm_aff_ref";
+const COOKIE_DAYS = 30;
+
+function setCookie(value: string) {
+  if (typeof document === "undefined") return;
+  const max = COOKIE_DAYS * 24 * 60 * 60;
+  document.cookie = `${COOKIE_NAME}=${encodeURIComponent(
+    value
+  )}; max-age=${max}; path=/; SameSite=Lax`;
+}
+
+export function getAffiliateRefCookie(): string | null {
+  if (typeof document === "undefined") return null;
+  const match = document.cookie.match(
+    new RegExp(`(?:^|; )${COOKIE_NAME}=([^;]*)`)
+  );
+  return match ? decodeURIComponent(match[1]!) : null;
+}
+
+/**
+ * Listens for `?ref=CODE` (or `?ref_seller=PUBKEY:CODE`) on every route change
+ * and stashes the value in a 30-day cookie. The cart later reads the cookie
+ * to pre-fill the affiliate code at checkout.
+ */
+export default function AffiliateRefTracker() {
+  const router = useRouter();
+  useEffect(() => {
+    const code = router.query.ref;
+    if (typeof code === "string" && code.length > 0 && code.length < 256) {
+      setCookie(code.trim());
+    }
+  }, [router.query.ref]);
+  return null;
+}

--- a/components/utility-components/affiliate-ref-tracker.tsx
+++ b/components/utility-components/affiliate-ref-tracker.tsx
@@ -3,35 +3,116 @@ import { useRouter } from "next/router";
 
 const COOKIE_NAME = "mm_aff_ref";
 const COOKIE_DAYS = 30;
+const MAX_ENTRIES = 32;
+// One sessionStorage marker per (seller, code) pair so a refresh inside the
+// same tab session doesn't double-count the click. We accept that opening a
+// link in a new tab counts twice — that's the same trade-off Plausible et al
+// make and avoids server-side dedupe on a public, unauthenticated endpoint.
+const SESSION_KEY = "mm_aff_clicks_recorded";
 
-function setCookie(value: string) {
-  if (typeof document === "undefined") return;
-  const max = COOKIE_DAYS * 24 * 60 * 60;
-  document.cookie = `${COOKIE_NAME}=${encodeURIComponent(
-    value
-  )}; max-age=${max}; path=/; SameSite=Lax`;
-}
+type RefMap = Record<string, string>;
 
-export function getAffiliateRefCookie(): string | null {
-  if (typeof document === "undefined") return null;
+function readMap(): RefMap {
+  if (typeof document === "undefined") return {};
   const match = document.cookie.match(
     new RegExp(`(?:^|; )${COOKIE_NAME}=([^;]*)`)
   );
-  return match ? decodeURIComponent(match[1]!) : null;
+  if (!match) return {};
+  try {
+    const parsed = JSON.parse(decodeURIComponent(match[1]!));
+    if (parsed && typeof parsed === "object") return parsed as RefMap;
+  } catch {
+    // legacy cookies stored a bare string under the "*" wildcard slot
+    return { "*": decodeURIComponent(match[1]!) };
+  }
+  return {};
+}
+
+function writeMap(map: RefMap) {
+  if (typeof document === "undefined") return;
+  const max = COOKIE_DAYS * 24 * 60 * 60;
+  const value = encodeURIComponent(JSON.stringify(map));
+  document.cookie = `${COOKIE_NAME}=${value}; max-age=${max}; path=/; SameSite=Lax`;
+}
+
+function setRefForSeller(code: string, sellerPubkey: string | null) {
+  const map = readMap();
+  const key = sellerPubkey || "*";
+  map[key] = code;
+  // bound map size so a malicious site can't fill the cookie
+  const keys = Object.keys(map);
+  if (keys.length > MAX_ENTRIES) {
+    for (const k of keys.slice(0, keys.length - MAX_ENTRIES)) delete map[k];
+  }
+  writeMap(map);
 }
 
 /**
- * Listens for `?ref=CODE` (or `?ref_seller=PUBKEY:CODE`) on every route change
- * and stashes the value in a 30-day cookie. The cart later reads the cookie
- * to pre-fill the affiliate code at checkout.
+ * Returns the most appropriate stored affiliate code for a given seller. We
+ * prefer a per-seller binding over the wildcard fallback so that a code set
+ * on seller A's product page does not get applied at seller B's checkout.
+ */
+export function getAffiliateRefCookie(
+  sellerPubkey?: string | null
+): string | null {
+  const map = readMap();
+  if (sellerPubkey && map[sellerPubkey]) return map[sellerPubkey] ?? null;
+  return map["*"] ?? null;
+}
+
+/**
+ * Listens for `?ref=CODE` on every route change and stashes the value in a
+ * 30-day cookie. If `?ref_seller=PUBKEY` is also present we bind the code to
+ * that seller; otherwise we store under the wildcard slot.
  */
 export default function AffiliateRefTracker() {
   const router = useRouter();
   useEffect(() => {
     const code = router.query.ref;
-    if (typeof code === "string" && code.length > 0 && code.length < 256) {
-      setCookie(code.trim());
+    const sellerRaw = router.query.ref_seller;
+    if (typeof code !== "string" || code.length === 0 || code.length >= 256) {
+      return;
     }
-  }, [router.query.ref]);
+    const seller =
+      typeof sellerRaw === "string" && /^[0-9a-f]{64}$/i.test(sellerRaw)
+        ? sellerRaw.toLowerCase()
+        : null;
+    const trimmed = code.trim();
+    setRefForSeller(trimmed, seller);
+
+    // Fire-and-forget click record. Only run when we know which seller the
+    // code belongs to — `record-click` requires a sellerPubkey for scoping.
+    if (!seller) return;
+    try {
+      const marker = `${seller}:${trimmed}`;
+      const seen =
+        typeof window !== "undefined" && window.sessionStorage
+          ? window.sessionStorage.getItem(SESSION_KEY)
+          : null;
+      const seenSet = new Set(seen ? seen.split("|") : []);
+      if (seenSet.has(marker)) return;
+      seenSet.add(marker);
+      if (typeof window !== "undefined" && window.sessionStorage) {
+        window.sessionStorage.setItem(
+          SESSION_KEY,
+          Array.from(seenSet).slice(-64).join("|")
+        );
+      }
+      void fetch("/api/affiliates/record-click", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          sellerPubkey: seller,
+          code: trimmed,
+          landingPath: router.asPath?.slice(0, 512) ?? null,
+        }),
+        keepalive: true,
+      }).catch(() => {
+        // best-effort; don't surface analytics errors to the user
+      });
+    } catch {
+      // sessionStorage unavailable (Safari private mode, etc); skip silently.
+    }
+  }, [router.query.ref, router.query.ref_seller, router.asPath]);
   return null;
 }

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -459,3 +459,119 @@ CREATE TABLE IF NOT EXISTS inventory_log (
 
 CREATE INDEX IF NOT EXISTS idx_inventory_log_product_id ON inventory_log(product_id);
 CREATE INDEX IF NOT EXISTS idx_inventory_log_order_id ON inventory_log(order_id);
+
+-- ============================================================================
+-- Affiliate program: seller-managed referral codes/links with configurable
+-- buyer discounts, affiliate rebates, payout schedules, and connected payout
+-- destinations (lightning address or Stripe Connect account). When no payout
+-- destination is set, balances accrue for out-of-band manual settlement.
+-- ============================================================================
+
+-- Affiliate identity. Created by the seller, optionally claimed by the
+-- affiliate via a unique invite token to set their own payout method.
+CREATE TABLE IF NOT EXISTS affiliates (
+    id SERIAL PRIMARY KEY,
+    seller_pubkey TEXT NOT NULL,
+    name TEXT NOT NULL,
+    email TEXT,
+    -- Affiliate's own platform pubkey (only set when they claim the invite
+    -- and sign in). Used to gate the self-service page after claim.
+    affiliate_pubkey TEXT,
+    -- Single-use-ish opaque token used in the affiliate self-service URL.
+    invite_token TEXT NOT NULL UNIQUE,
+    invite_claimed_at TIMESTAMP,
+    -- Payout destinations (either, both, or neither may be set).
+    lightning_address TEXT,
+    stripe_account_id TEXT,
+    notes TEXT,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX IF NOT EXISTS idx_affiliates_seller_pubkey ON affiliates(seller_pubkey);
+CREATE INDEX IF NOT EXISTS idx_affiliates_invite_token ON affiliates(invite_token);
+CREATE INDEX IF NOT EXISTS idx_affiliates_affiliate_pubkey ON affiliates(affiliate_pubkey);
+
+-- Referral codes/links bound to an affiliate. A single affiliate can own
+-- many codes (e.g. for different campaigns).
+CREATE TABLE IF NOT EXISTS affiliate_codes (
+    id SERIAL PRIMARY KEY,
+    affiliate_id INTEGER NOT NULL REFERENCES affiliates(id) ON DELETE CASCADE,
+    seller_pubkey TEXT NOT NULL,
+    code TEXT NOT NULL,
+    -- Affiliate rebate (commission) applied to the seller's net subtotal.
+    rebate_type TEXT NOT NULL CHECK (rebate_type IN ('percent', 'fixed')),
+    rebate_value NUMERIC(12,2) NOT NULL CHECK (rebate_value >= 0),
+    -- Buyer discount applied at checkout.
+    buyer_discount_type TEXT NOT NULL DEFAULT 'percent' CHECK (buyer_discount_type IN ('percent', 'fixed')),
+    buyer_discount_value NUMERIC(12,2) NOT NULL DEFAULT 0 CHECK (buyer_discount_value >= 0),
+    -- Currency hint for fixed-amount values (uses seller's primary currency
+    -- when null; sats are also supported for bitcoin orders).
+    currency TEXT,
+    -- Payout cadence for accrued affiliate rebates.
+    payout_schedule TEXT NOT NULL DEFAULT 'every_sale' CHECK (payout_schedule IN ('every_sale', 'daily', 'weekly', 'monthly')),
+    expiration BIGINT,
+    max_uses INTEGER,
+    times_used INTEGER NOT NULL DEFAULT 0,
+    is_active BOOLEAN NOT NULL DEFAULT TRUE,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE(seller_pubkey, code)
+);
+
+CREATE INDEX IF NOT EXISTS idx_affiliate_codes_seller_pubkey ON affiliate_codes(seller_pubkey);
+CREATE INDEX IF NOT EXISTS idx_affiliate_codes_affiliate_id ON affiliate_codes(affiliate_id);
+CREATE INDEX IF NOT EXISTS idx_affiliate_codes_code ON affiliate_codes(code);
+
+-- One row per attributed sale. The rebate is captured at order time and
+-- moves through the lifecycle pending -> payable -> paid (or skipped on
+-- refund/cancel).
+CREATE TABLE IF NOT EXISTS affiliate_referrals (
+    id SERIAL PRIMARY KEY,
+    affiliate_id INTEGER NOT NULL REFERENCES affiliates(id) ON DELETE CASCADE,
+    code_id INTEGER NOT NULL REFERENCES affiliate_codes(id) ON DELETE CASCADE,
+    seller_pubkey TEXT NOT NULL,
+    order_id TEXT NOT NULL,
+    payment_rail TEXT NOT NULL CHECK (payment_rail IN ('stripe', 'bitcoin')),
+    -- Order subtotal in smallest units of `currency` (cents for fiat, sats
+    -- for sats). The rebate amount is precomputed using the code config.
+    gross_subtotal_smallest NUMERIC(20,0) NOT NULL,
+    buyer_discount_smallest NUMERIC(20,0) NOT NULL DEFAULT 0,
+    rebate_smallest NUMERIC(20,0) NOT NULL DEFAULT 0,
+    currency TEXT NOT NULL,
+    -- Payout state machine.
+    status TEXT NOT NULL DEFAULT 'pending' CHECK (status IN ('pending', 'payable', 'paid', 'cancelled')),
+    -- Set when this referral has been paid out (real-time or batched).
+    payout_id INTEGER,
+    -- Real-time-payout transfer id (Stripe transfer / LN payment hash).
+    realtime_transfer_ref TEXT,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE(order_id, code_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_affiliate_referrals_affiliate_id ON affiliate_referrals(affiliate_id);
+CREATE INDEX IF NOT EXISTS idx_affiliate_referrals_seller_pubkey ON affiliate_referrals(seller_pubkey);
+CREATE INDEX IF NOT EXISTS idx_affiliate_referrals_status ON affiliate_referrals(status);
+CREATE INDEX IF NOT EXISTS idx_affiliate_referrals_order_id ON affiliate_referrals(order_id);
+
+-- Aggregated payout records. A payout groups one or more referrals into
+-- a single settlement (real-time, scheduled, or marked-as-paid manually).
+CREATE TABLE IF NOT EXISTS affiliate_payouts (
+    id SERIAL PRIMARY KEY,
+    affiliate_id INTEGER NOT NULL REFERENCES affiliates(id) ON DELETE CASCADE,
+    seller_pubkey TEXT NOT NULL,
+    method TEXT NOT NULL CHECK (method IN ('stripe', 'lightning', 'manual')),
+    amount_smallest NUMERIC(20,0) NOT NULL,
+    currency TEXT NOT NULL,
+    -- External reference: stripe transfer id, LN payment hash, or free-form
+    -- note for manual payouts.
+    external_ref TEXT,
+    note TEXT,
+    status TEXT NOT NULL DEFAULT 'paid' CHECK (status IN ('paid', 'failed')),
+    paid_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX IF NOT EXISTS idx_affiliate_payouts_affiliate_id ON affiliate_payouts(affiliate_id);
+CREATE INDEX IF NOT EXISTS idx_affiliate_payouts_seller_pubkey ON affiliate_payouts(seller_pubkey);

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -488,6 +488,34 @@ CREATE TABLE IF NOT EXISTS affiliates (
     updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );
 
+-- Defaults for the failure-tracking columns added below in the migration
+-- block. Listed inline as well so freshly-created databases get them on the
+-- first CREATE TABLE pass.
+ALTER TABLE affiliates ADD COLUMN IF NOT EXISTS payouts_enabled BOOLEAN NOT NULL DEFAULT TRUE;
+ALTER TABLE affiliates ADD COLUMN IF NOT EXISTS payout_failure_count INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE affiliates ADD COLUMN IF NOT EXISTS last_payout_failure_at TIMESTAMP;
+ALTER TABLE affiliates ADD COLUMN IF NOT EXISTS last_payout_failure_reason TEXT;
+ALTER TABLE affiliates ADD COLUMN IF NOT EXISTS email_notifications_enabled BOOLEAN NOT NULL DEFAULT TRUE;
+ALTER TABLE affiliates ADD COLUMN IF NOT EXISTS stripe_charges_enabled BOOLEAN NOT NULL DEFAULT FALSE;
+ALTER TABLE affiliates ADD COLUMN IF NOT EXISTS stripe_payouts_enabled BOOLEAN NOT NULL DEFAULT FALSE;
+ALTER TABLE affiliates ADD COLUMN IF NOT EXISTS stripe_onboarding_complete BOOLEAN NOT NULL DEFAULT FALSE;
+
+-- Lightweight click-through tracking for affiliate links. One row per page
+-- impression where ?ref=CODE was present. Keeps just enough metadata to
+-- compute conversion rate; intentionally no IP, no user-agent fingerprint.
+CREATE TABLE IF NOT EXISTS affiliate_clicks (
+    id BIGSERIAL PRIMARY KEY,
+    seller_pubkey TEXT NOT NULL,
+    code TEXT NOT NULL,
+    landing_path TEXT,
+    referer_host TEXT,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+CREATE INDEX IF NOT EXISTS idx_affiliate_clicks_seller_code
+  ON affiliate_clicks(seller_pubkey, code);
+CREATE INDEX IF NOT EXISTS idx_affiliate_clicks_created_at
+  ON affiliate_clicks(created_at);
+
 CREATE INDEX IF NOT EXISTS idx_affiliates_seller_pubkey ON affiliates(seller_pubkey);
 CREATE INDEX IF NOT EXISTS idx_affiliates_invite_token ON affiliates(invite_token);
 CREATE INDEX IF NOT EXISTS idx_affiliates_affiliate_pubkey ON affiliates(affiliate_pubkey);
@@ -508,8 +536,10 @@ CREATE TABLE IF NOT EXISTS affiliate_codes (
     -- Currency hint for fixed-amount values (uses seller's primary currency
     -- when null; sats are also supported for bitcoin orders).
     currency TEXT,
-    -- Payout cadence for accrued affiliate rebates.
-    payout_schedule TEXT NOT NULL DEFAULT 'every_sale' CHECK (payout_schedule IN ('every_sale', 'daily', 'weekly', 'monthly')),
+    -- Payout cadence for accrued affiliate rebates. Real-time payouts were
+    -- removed to make refund clawbacks deterministic — everything accrues and
+    -- is settled in batch by the cron at the configured cadence.
+    payout_schedule TEXT NOT NULL DEFAULT 'monthly' CHECK (payout_schedule IN ('weekly', 'biweekly', 'monthly')),
     expiration BIGINT,
     max_uses INTEGER,
     times_used INTEGER NOT NULL DEFAULT 0,
@@ -540,11 +570,16 @@ CREATE TABLE IF NOT EXISTS affiliate_referrals (
     rebate_smallest NUMERIC(20,0) NOT NULL DEFAULT 0,
     currency TEXT NOT NULL,
     -- Payout state machine.
-    status TEXT NOT NULL DEFAULT 'pending' CHECK (status IN ('pending', 'payable', 'paid', 'cancelled')),
-    -- Set when this referral has been paid out (real-time or batched).
+    status TEXT NOT NULL DEFAULT 'pending' CHECK (status IN ('pending', 'payable', 'paid', 'cancelled', 'refunded')),
+    -- Set when this referral has been paid out by the scheduled cron job.
     payout_id INTEGER,
-    -- Real-time-payout transfer id (Stripe transfer / LN payment hash).
+    -- Reserved column kept for back-compat. Real-time payouts were removed.
     realtime_transfer_ref TEXT,
+    -- Refund/clawback bookkeeping. When the order is refunded after the
+    -- referral has already been paid out, we mark the original 'paid'
+    -- referral as 'refunded' and record the refunded amount + Stripe ref.
+    refunded_smallest NUMERIC(20,0) NOT NULL DEFAULT 0,
+    refund_event_ref TEXT,
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     UNIQUE(order_id, code_id)
@@ -575,3 +610,56 @@ CREATE TABLE IF NOT EXISTS affiliate_payouts (
 
 CREATE INDEX IF NOT EXISTS idx_affiliate_payouts_affiliate_id ON affiliate_payouts(affiliate_id);
 CREATE INDEX IF NOT EXISTS idx_affiliate_payouts_seller_pubkey ON affiliate_payouts(seller_pubkey);
+
+-- ============================================================================
+-- Affiliate program migration: tighten payout schedule to weekly/biweekly/
+-- monthly (real-time rebates removed), add 'refunded' status + clawback
+-- columns. Idempotent so existing databases can be re-applied safely.
+-- ============================================================================
+DO $aff_migrate$
+BEGIN
+  -- Map deprecated schedules onto the new defaults.
+  EXECUTE 'UPDATE affiliate_codes SET payout_schedule = ''monthly'' WHERE payout_schedule IN (''every_sale'', ''daily'')';
+  -- Replace the old CHECK constraint.
+  IF EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'affiliate_codes_payout_schedule_check'
+  ) THEN
+    ALTER TABLE affiliate_codes DROP CONSTRAINT affiliate_codes_payout_schedule_check;
+  END IF;
+  ALTER TABLE affiliate_codes
+    ADD CONSTRAINT affiliate_codes_payout_schedule_check
+    CHECK (payout_schedule IN ('weekly', 'biweekly', 'monthly'));
+  ALTER TABLE affiliate_codes ALTER COLUMN payout_schedule SET DEFAULT 'monthly';
+
+  -- Refund/clawback columns on referrals.
+  ALTER TABLE affiliate_referrals
+    ADD COLUMN IF NOT EXISTS refunded_smallest NUMERIC(20,0) NOT NULL DEFAULT 0;
+  ALTER TABLE affiliate_referrals
+    ADD COLUMN IF NOT EXISTS refund_event_ref TEXT;
+  -- Allow 'refunded' status.
+  IF EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'affiliate_referrals_status_check'
+  ) THEN
+    ALTER TABLE affiliate_referrals DROP CONSTRAINT affiliate_referrals_status_check;
+  END IF;
+  ALTER TABLE affiliate_referrals
+    ADD CONSTRAINT affiliate_referrals_status_check
+    CHECK (status IN ('pending', 'payable', 'paid', 'cancelled', 'refunded'));
+
+  -- Payout enable/disable flag + failure tracking on affiliates.
+  ALTER TABLE affiliates
+    ADD COLUMN IF NOT EXISTS payouts_enabled BOOLEAN NOT NULL DEFAULT TRUE;
+  ALTER TABLE affiliates
+    ADD COLUMN IF NOT EXISTS payout_failure_count INTEGER NOT NULL DEFAULT 0;
+  ALTER TABLE affiliates
+    ADD COLUMN IF NOT EXISTS last_payout_failure_at TIMESTAMP;
+  ALTER TABLE affiliates
+    ADD COLUMN IF NOT EXISTS last_payout_failure_reason TEXT;
+
+  -- Case-insensitive uniqueness for affiliate codes scoped per seller. The
+  -- existing UNIQUE(seller_pubkey, code) is case-sensitive; this functional
+  -- index closes the gap so 'SAVE10' and 'save10' can't both exist.
+  CREATE UNIQUE INDEX IF NOT EXISTS uniq_affiliate_codes_seller_upper_code
+    ON affiliate_codes (seller_pubkey, UPPER(code));
+END
+$aff_migrate$;

--- a/docs/affiliate-payout-cron.md
+++ b/docs/affiliate-payout-cron.md
@@ -1,0 +1,78 @@
+# Affiliate payout scheduling
+
+The `/api/affiliates/process-payouts` endpoint promotes pending referrals to
+"payable" once they pass the configured hold window for their schedule, then
+settles each payable bundle (Stripe Connect transfer for fiat, or fetches a
+Lightning invoice for sats). It is intentionally cron-driven rather than
+inline so refund clawbacks remain deterministic.
+
+## Required environment
+
+- `AFFILIATE_PAYOUT_CRON_SECRET` — a long random string. Required for the
+  endpoint to even respond; missing the secret returns a 500.
+- `STRIPE_SECRET_KEY` — for fiat transfers. Lightning runs without it.
+- `NEXT_PUBLIC_BASE_URL` (or `REPLIT_DEV_DOMAIN`) — used by the cron command
+  example below.
+
+## Recommended schedules
+
+The autoscale runtime can't host long-lived crons, so configure each cadence
+as a Replit **Scheduled Deployment** (or any external cron) hitting the
+endpoint with the cadence in the query string.
+
+| Schedule | Cron (UTC)      | Hold window | Notes                               |
+| -------- | --------------- | ----------- | ----------------------------------- |
+| weekly   | `0 14 * * 1`    | 7 days      | Mondays at 14:00 UTC                |
+| biweekly | `0 14 1,15 * *` | 14 days     | 1st and 15th at 14:00 UTC           |
+| monthly  | `0 14 1 * *`    | 30 days     | 1st of month at 14:00 UTC (default) |
+
+Each scheduled job should run a single command:
+
+```sh
+curl -fsSL -X POST \
+  -H "Authorization: Bearer $AFFILIATE_PAYOUT_CRON_SECRET" \
+  "$NEXT_PUBLIC_BASE_URL/api/affiliates/process-payouts?schedule=weekly"
+```
+
+Use `?dryRun=1` first to preview which bundles would be settled without
+touching state.
+
+## Safety guarantees
+
+- **Per-schedule advisory lock** (Postgres key 91_001..91_003) refuses
+  concurrent runs of the same cadence so two crons can't double-pay.
+- **Per-affiliate advisory lock** (key 92_000_000 + affiliate_id) refuses
+  cross-cadence races on the same affiliate.
+- **Stable Stripe idempotency key** is computed from the sorted referral IDs
+  so a retry after a crash returns the original transfer instead of creating
+  a duplicate.
+- **Auto-pause** flips `payouts_enabled = false` after
+  `MAX_PAYOUT_FAILURES` (5) consecutive failures and emails both the
+  affiliate and the seller exactly once at the moment of pause.
+- **Hold window** ensures buyers have at least 7/14/30 days to refund before
+  any rebate is settled.
+
+## Reconciliation
+
+Run `pnpm tsx scripts/reconcile-affiliate-balances.ts` periodically (e.g.
+daily) to spot orphan paid rows, refund overshoots, and stale payable rows.
+Pass `--apply` to demote orphan paid rows back to payable.
+
+## Year-to-date totals (1099 reporting)
+
+`GET /api/affiliates/ytd-payouts?pubkey=<seller>&year=<YYYY>` returns paid
+totals per affiliate for the requested year, plus a list of affiliate IDs
+flagged for the US 1099-NEC threshold ($600 in non-employee compensation).
+The seller is responsible for issuing the actual forms (Stripe Tax 1099 is
+the easiest path for US sellers).
+
+## Partial refund accounting
+
+When a single Stripe charge spans multiple sellers and is partially refunded,
+Stripe's webhook payload doesn't break the refund down per seller. The
+`reverseReferralsForOrder` helper applies the refund ratio globally — it
+scales every pending rebate on that order by `refunded / original_gross`. In
+the rare case where a buyer refunds only one seller's portion of a
+multi-seller cart, the resulting clawback is best-effort and should be
+reconciled manually using the Stripe dashboard. This is documented as a
+known limitation.

--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -16,8 +16,13 @@ const customJestConfig = {
 
 module.exports = async () => {
   const jestConfig = await createJestConfig(customJestConfig)();
+  // Note: pnpm hoists modules under node_modules/.pnpm/<pkg>@<ver>/node_modules/<pkg>.
+  // The negative lookahead has to handle BOTH the classic `node_modules/@noble/...`
+  // layout and the pnpm `node_modules/.pnpm/.../node_modules/@noble/...` layout,
+  // otherwise ESM-only deps like @noble/hashes/sha2.js are passed through to
+  // Node untransformed and crash with "Cannot use import statement outside a module".
   jestConfig.transformIgnorePatterns = [
-    "/node_modules/(?!(dexie|nostr-tools|@noble|@scure|@getalby/lightning-tools|@cashu/cashu-ts|uuid)/)",
+    "/node_modules/(?:\\.pnpm/[^/]+/node_modules/)?(?!(dexie|nostr-tools|@noble|@scure|@getalby/lightning-tools|@cashu/cashu-ts|uuid)/)",
     "^.+\\.module\\.(css|sass|scss)$",
   ];
 

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -66,6 +66,7 @@ import {
 } from "@/components/utility-components/nostr-context-provider";
 import { retryFailedRelayPublishes } from "@/utils/nostr/retry-service";
 import { MintRecoveryBoot } from "@/components/utility-components/mint-recovery-boot";
+import AffiliateRefTracker from "@/components/utility-components/affiliate-ref-tracker";
 import { NostrManager } from "@/utils/nostr/nostr-manager";
 
 function MilkMarket({ props }: { props: AppProps }) {
@@ -1289,6 +1290,7 @@ function MilkMarket({ props }: { props: AppProps }) {
       />
       <StructuredData />
       <PageLoadingBar />
+      <AffiliateRefTracker />
       <RelaysContext.Provider value={relaysContext}>
         <BlossomContext.Provider value={blossomContext}>
           <CashuWalletContext.Provider value={cashuWalletContext}>

--- a/pages/affiliate/[token].tsx
+++ b/pages/affiliate/[token].tsx
@@ -1,5 +1,5 @@
 import { GetServerSideProps } from "next";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useRouter } from "next/router";
 import { Button, Card, CardBody, CardHeader, Input } from "@heroui/react";
 import { BLUEBUTTONCLASSNAMES } from "@/utils/STATIC-VARIABLES";
@@ -13,11 +13,49 @@ interface AffiliateInfo {
   invite_claimed_at: string | null;
   lightning_address: string | null;
   stripe_account_id: string | null;
+  has_lightning_address?: boolean;
+  has_stripe_account?: boolean;
+  masked?: boolean;
+}
+
+interface SelfBalance {
+  currency: string;
+  pending_smallest: string;
+  payable_smallest: string;
+  paid_smallest: string;
+}
+
+interface SelfPayout {
+  id: number;
+  method: "stripe" | "lightning" | "manual";
+  amount_smallest: string;
+  currency: string;
+  status: string;
+  paid_at: string;
+  external_ref: string | null;
+}
+
+interface SelfStats {
+  affiliateId: number;
+  name: string;
+  payoutsEnabled: boolean;
+  lastFailureReason: string | null;
+  lastFailureAt: string | null;
+  balances: SelfBalance[];
+  payouts: SelfPayout[];
 }
 
 interface Props {
   token: string;
   initial: AffiliateInfo | null;
+}
+
+function formatAmount(amountSmallest: string, currency: string): string {
+  const n = Number(amountSmallest || 0);
+  if (currency.toLowerCase() === "sats") {
+    return `${n.toLocaleString()} sats`;
+  }
+  return `${(n / 100).toFixed(2)} ${currency.toUpperCase()}`;
 }
 
 export default function AffiliateClaimPage({ token, initial }: Props) {
@@ -31,6 +69,32 @@ export default function AffiliateClaimPage({ token, initial }: Props) {
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [saved, setSaved] = useState(false);
+  const [stats, setStats] = useState<SelfStats | null>(null);
+  const [statsErr, setStatsErr] = useState<string | null>(null);
+  const [stripeBusy, setStripeBusy] = useState(false);
+
+  useEffect(() => {
+    if (!token) return;
+    let cancelled = false;
+    (async () => {
+      try {
+        const r = await fetch(
+          `/api/affiliates/self-stats?token=${encodeURIComponent(token)}`
+        );
+        if (!r.ok) {
+          if (!cancelled) setStatsErr("Couldn't load your balances right now.");
+          return;
+        }
+        const j = (await r.json()) as SelfStats;
+        if (!cancelled) setStats(j);
+      } catch {
+        if (!cancelled) setStatsErr("Couldn't load your balances right now.");
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [token]);
 
   if (!affiliate) {
     return (
@@ -73,9 +137,51 @@ export default function AffiliateClaimPage({ token, initial }: Props) {
     }
   }
 
+  async function startStripeOnboarding() {
+    setStripeBusy(true);
+    setError(null);
+    try {
+      // Step 1: ensure an account exists (idempotent if already created).
+      const create = await fetch("/api/affiliates/stripe-onboarding", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          token,
+          action: "create-account",
+          affiliatePubkey: pubkey || null,
+        }),
+      });
+      const createJson = await create.json();
+      if (!create.ok) {
+        setError(createJson.error || "Failed to create Stripe account");
+        return;
+      }
+      // Step 2: get a link the affiliate can complete onboarding through.
+      const link = await fetch("/api/affiliates/stripe-onboarding", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          token,
+          action: "create-link",
+          affiliatePubkey: pubkey || null,
+        }),
+      });
+      const linkJson = await link.json();
+      if (!link.ok || !linkJson.url) {
+        setError(linkJson.error || "Failed to get onboarding link");
+        return;
+      }
+      window.location.href = linkJson.url;
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Stripe onboarding failed");
+    } finally {
+      setStripeBusy(false);
+    }
+  }
+
   return (
-    <div className="mx-auto max-w-xl p-8">
-      <div className="mb-6">
+    <div className="mx-auto max-w-2xl space-y-6 p-8">
+      <div>
         <h1 className="text-2xl font-bold text-black">
           Welcome, {affiliate.name}
         </h1>
@@ -85,6 +191,62 @@ export default function AffiliateClaimPage({ token, initial }: Props) {
           update your payout details.
         </p>
       </div>
+
+      {stats && !stats.payoutsEnabled && (
+        <Card className="border border-amber-200 bg-amber-50">
+          <CardBody>
+            <p className="text-sm font-semibold text-amber-900">
+              Your payouts are currently paused.
+            </p>
+            {stats.lastFailureReason && (
+              <p className="mt-1 text-sm text-amber-800">
+                Last error: {stats.lastFailureReason}
+              </p>
+            )}
+            <p className="mt-2 text-sm text-amber-800">
+              Update your payout details below and ask the seller to re-enable
+              payouts from their dashboard.
+            </p>
+          </CardBody>
+        </Card>
+      )}
+
+      <Card className="bg-white">
+        <CardHeader>
+          <h2 className="text-lg font-semibold text-black">Your balances</h2>
+        </CardHeader>
+        <CardBody className="space-y-2">
+          {statsErr && <p className="text-sm text-red-600">{statsErr}</p>}
+          {!stats && !statsErr && (
+            <p className="text-sm text-gray-500">Loading…</p>
+          )}
+          {stats && stats.balances.length === 0 && (
+            <p className="text-sm text-gray-500">
+              No referrals yet. Share your code to start earning.
+            </p>
+          )}
+          {stats &&
+            stats.balances.map((b) => (
+              <div
+                key={b.currency}
+                className="flex flex-wrap items-center justify-between gap-2 rounded border border-gray-200 p-3 text-sm"
+              >
+                <span className="font-mono text-xs text-gray-500 uppercase">
+                  {b.currency}
+                </span>
+                <span className="text-gray-700">
+                  Pending: {formatAmount(b.pending_smallest, b.currency)}
+                </span>
+                <span className="text-gray-700">
+                  Ready: {formatAmount(b.payable_smallest, b.currency)}
+                </span>
+                <span className="font-semibold text-black">
+                  Paid: {formatAmount(b.paid_smallest, b.currency)}
+                </span>
+              </div>
+            ))}
+        </CardBody>
+      </Card>
 
       <Card className="bg-white">
         <CardHeader>
@@ -108,26 +270,78 @@ export default function AffiliateClaimPage({ token, initial }: Props) {
             placeholder="acct_..."
             value={stripeAcct}
             onChange={(e) => setStripeAcct(e.target.value)}
-            description="If filled, the seller's Stripe orders will pay you in real time."
+            description="If filled, the seller's Stripe orders will pay you on schedule."
           />
+          <div>
+            <Button
+              variant="bordered"
+              className="text-black"
+              onClick={startStripeOnboarding}
+              isLoading={stripeBusy}
+            >
+              {affiliate.stripe_account_id
+                ? "Continue Stripe onboarding"
+                : "Set up Stripe Connect for me"}
+            </Button>
+            <p className="mt-1 text-xs text-gray-500">
+              We&apos;ll create a Stripe Express account on your behalf and
+              redirect you to finish onboarding.
+            </p>
+          </div>
           {error && <p className="text-sm text-red-600">{error}</p>}
           {saved && <p className="text-sm text-green-600">Saved.</p>}
-          <Button
-            className={BLUEBUTTONCLASSNAMES}
-            onClick={save}
-            isLoading={saving}
-          >
-            Save payout details
-          </Button>
-          <Button
-            variant="light"
-            className="text-black"
-            onClick={() => router.back()}
-          >
-            Back
-          </Button>
+          <div className="flex gap-2">
+            <Button
+              className={BLUEBUTTONCLASSNAMES}
+              onClick={save}
+              isLoading={saving}
+            >
+              Save payout details
+            </Button>
+            <Button
+              variant="light"
+              className="text-black"
+              onClick={() => router.back()}
+            >
+              Back
+            </Button>
+          </div>
         </CardBody>
       </Card>
+
+      {stats && stats.payouts.length > 0 && (
+        <Card className="bg-white">
+          <CardHeader>
+            <h2 className="text-lg font-semibold text-black">Recent payouts</h2>
+          </CardHeader>
+          <CardBody>
+            <table className="w-full text-sm">
+              <thead className="text-left text-xs text-gray-500 uppercase">
+                <tr>
+                  <th className="py-1">Date</th>
+                  <th className="py-1">Method</th>
+                  <th className="py-1">Amount</th>
+                  <th className="py-1">Status</th>
+                </tr>
+              </thead>
+              <tbody>
+                {stats.payouts.map((p) => (
+                  <tr key={p.id} className="border-t border-gray-100">
+                    <td className="py-1 text-gray-700">
+                      {new Date(p.paid_at).toLocaleDateString()}
+                    </td>
+                    <td className="py-1 text-gray-700">{p.method}</td>
+                    <td className="py-1 text-gray-700">
+                      {formatAmount(p.amount_smallest, p.currency)}
+                    </td>
+                    <td className="py-1 text-gray-700">{p.status}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </CardBody>
+        </Card>
+      )}
     </div>
   );
 }

--- a/pages/affiliate/[token].tsx
+++ b/pages/affiliate/[token].tsx
@@ -1,0 +1,151 @@
+import { GetServerSideProps } from "next";
+import { useState } from "react";
+import { useRouter } from "next/router";
+import { Button, Card, CardBody, CardHeader, Input } from "@heroui/react";
+import { BLUEBUTTONCLASSNAMES } from "@/utils/STATIC-VARIABLES";
+
+interface AffiliateInfo {
+  id: number;
+  seller_pubkey: string;
+  name: string;
+  email: string | null;
+  affiliate_pubkey: string | null;
+  invite_claimed_at: string | null;
+  lightning_address: string | null;
+  stripe_account_id: string | null;
+}
+
+interface Props {
+  token: string;
+  initial: AffiliateInfo | null;
+}
+
+export default function AffiliateClaimPage({ token, initial }: Props) {
+  const router = useRouter();
+  const [affiliate, setAffiliate] = useState<AffiliateInfo | null>(initial);
+  const [pubkey, setPubkey] = useState(initial?.affiliate_pubkey ?? "");
+  const [lightning, setLightning] = useState(initial?.lightning_address ?? "");
+  const [stripeAcct, setStripeAcct] = useState(
+    initial?.stripe_account_id ?? ""
+  );
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [saved, setSaved] = useState(false);
+
+  if (!affiliate) {
+    return (
+      <div className="mx-auto max-w-xl p-8">
+        <h1 className="text-2xl font-bold text-black">Invite not found</h1>
+        <p className="mt-2 text-gray-600">
+          This affiliate invite link is invalid or has been removed. Please ask
+          the seller for a new link.
+        </p>
+      </div>
+    );
+  }
+
+  async function save() {
+    setSaving(true);
+    setError(null);
+    setSaved(false);
+    try {
+      const res = await fetch("/api/affiliates/claim", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          token,
+          affiliatePubkey: pubkey || null,
+          lightningAddress: lightning || null,
+          stripeAccountId: stripeAcct || null,
+        }),
+      });
+      const data = await res.json();
+      if (!res.ok) {
+        setError(data.error || "Failed to save");
+      } else {
+        setAffiliate(data);
+        setSaved(true);
+      }
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to save");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <div className="mx-auto max-w-xl p-8">
+      <div className="mb-6">
+        <h1 className="text-2xl font-bold text-black">
+          Welcome, {affiliate.name}
+        </h1>
+        <p className="mt-2 text-sm text-gray-600">
+          Set your payout destination so the seller&apos;s store can send you
+          rebates automatically. Bookmark this page — anyone with this link can
+          update your payout details.
+        </p>
+      </div>
+
+      <Card className="bg-white">
+        <CardHeader>
+          <h2 className="text-lg font-semibold text-black">Payout details</h2>
+        </CardHeader>
+        <CardBody className="space-y-3">
+          <Input
+            label="Your Nostr pubkey (optional)"
+            value={pubkey}
+            onChange={(e) => setPubkey(e.target.value)}
+            description="Lets you sign in and view your stats from your own client."
+          />
+          <Input
+            label="Lightning address"
+            placeholder="you@getalby.com"
+            value={lightning}
+            onChange={(e) => setLightning(e.target.value)}
+          />
+          <Input
+            label="Stripe Connect account id"
+            placeholder="acct_..."
+            value={stripeAcct}
+            onChange={(e) => setStripeAcct(e.target.value)}
+            description="If filled, the seller's Stripe orders will pay you in real time."
+          />
+          {error && <p className="text-sm text-red-600">{error}</p>}
+          {saved && <p className="text-sm text-green-600">Saved.</p>}
+          <Button
+            className={BLUEBUTTONCLASSNAMES}
+            onClick={save}
+            isLoading={saving}
+          >
+            Save payout details
+          </Button>
+          <Button
+            variant="light"
+            className="text-black"
+            onClick={() => router.back()}
+          >
+            Back
+          </Button>
+        </CardBody>
+      </Card>
+    </div>
+  );
+}
+
+export const getServerSideProps: GetServerSideProps<Props> = async (ctx) => {
+  const token = String(ctx.params?.token ?? "");
+  try {
+    const proto = (ctx.req.headers["x-forwarded-proto"] as string) || "http";
+    const host = ctx.req.headers.host;
+    const res = await fetch(
+      `${proto}://${host}/api/affiliates/claim?token=${encodeURIComponent(
+        token
+      )}`
+    );
+    if (!res.ok) return { props: { token, initial: null } };
+    const initial = (await res.json()) as AffiliateInfo;
+    return { props: { token, initial } };
+  } catch {
+    return { props: { token, initial: null } };
+  }
+};

--- a/pages/api/affiliates/claim.ts
+++ b/pages/api/affiliates/claim.ts
@@ -4,8 +4,35 @@ import {
   updateAffiliatePayoutMethod,
 } from "@/utils/db/affiliates";
 import { applyRateLimit } from "@/utils/rate-limit";
+import {
+  buildAffiliateClaimUpdateProof,
+  extractSignedEventFromRequest,
+  verifySignedHttpRequestProof,
+} from "@/utils/nostr/request-auth";
 
 const RATE_LIMIT = { limit: 60, windowMs: 60 * 1000 };
+
+function maskEmail(e: string | null): string | null {
+  if (!e) return e;
+  const [local, domain] = e.split("@");
+  if (!domain) return "***";
+  const head = (local ?? "").slice(0, 2);
+  return `${head}***@${domain}`;
+}
+
+function maskLightningAddress(la: string | null): string | null {
+  if (!la) return la;
+  const [local, domain] = la.split("@");
+  if (!domain) return "***";
+  const head = (local ?? "").slice(0, 2);
+  return `${head}***@${domain}`;
+}
+
+function maskStripeAccount(acct: string | null): string | null {
+  if (!acct) return acct;
+  if (acct.length <= 8) return "acct_***";
+  return `${acct.slice(0, 5)}***${acct.slice(-4)}`;
+}
 
 /**
  * Affiliate self-service: load the affiliate record by invite token (GET) or
@@ -30,15 +57,28 @@ export default async function handler(
       }
       const a = await getAffiliateByInviteToken(token);
       if (!a) return res.status(404).json({ error: "Invite not found" });
+      // Once the invite has been claimed the GET response is reachable by
+      // anyone holding the link, so we mask payout destinations to a
+      // recognizable preview. The affiliate already knows their own values
+      // and can re-enter them to update; a casual link finder cannot harvest
+      // the lightning address or Stripe account.
+      const masked = !!a.affiliate_pubkey;
       return res.status(200).json({
         id: a.id,
         seller_pubkey: a.seller_pubkey,
         name: a.name,
-        email: a.email,
+        email: masked ? maskEmail(a.email) : a.email,
         affiliate_pubkey: a.affiliate_pubkey,
         invite_claimed_at: a.invite_claimed_at,
-        lightning_address: a.lightning_address,
-        stripe_account_id: a.stripe_account_id,
+        lightning_address: masked
+          ? maskLightningAddress(a.lightning_address)
+          : a.lightning_address,
+        stripe_account_id: masked
+          ? maskStripeAccount(a.stripe_account_id)
+          : a.stripe_account_id,
+        has_lightning_address: !!a.lightning_address,
+        has_stripe_account: !!a.stripe_account_id,
+        masked,
       });
     }
 
@@ -48,15 +88,30 @@ export default async function handler(
       if (!token) return res.status(400).json({ error: "token required" });
       const existing = await getAffiliateByInviteToken(String(token));
       if (!existing) return res.status(404).json({ error: "Invite not found" });
-      if (
-        existing.affiliate_pubkey &&
-        affiliatePubkey &&
-        existing.affiliate_pubkey !== affiliatePubkey
-      ) {
-        return res
-          .status(403)
-          .json({ error: "Invite already claimed by another pubkey" });
+
+      // Once an invite is claimed, the invite token alone is no longer
+      // sufficient — every subsequent update must be signed by the claiming
+      // pubkey to prevent a leaked link from being used to redirect
+      // payouts.
+      if (existing.affiliate_pubkey) {
+        if (!affiliatePubkey) {
+          return res.status(400).json({ error: "affiliatePubkey required" });
+        }
+        if (existing.affiliate_pubkey !== affiliatePubkey) {
+          return res
+            .status(403)
+            .json({ error: "Invite already claimed by another pubkey" });
+        }
+        const v = verifySignedHttpRequestProof(
+          extractSignedEventFromRequest(req),
+          buildAffiliateClaimUpdateProof({
+            pubkey: affiliatePubkey,
+            inviteToken: String(token),
+          })
+        );
+        if (!v.ok) return res.status(v.status).json({ error: v.error });
       }
+
       const updated = await updateAffiliatePayoutMethod(String(token), {
         affiliatePubkey: affiliatePubkey ?? existing.affiliate_pubkey ?? null,
         lightningAddress: lightningAddress ?? null,

--- a/pages/api/affiliates/claim.ts
+++ b/pages/api/affiliates/claim.ts
@@ -1,0 +1,73 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import {
+  getAffiliateByInviteToken,
+  updateAffiliatePayoutMethod,
+} from "@/utils/db/affiliates";
+import { applyRateLimit } from "@/utils/rate-limit";
+
+const RATE_LIMIT = { limit: 60, windowMs: 60 * 1000 };
+
+/**
+ * Affiliate self-service: load the affiliate record by invite token (GET) or
+ * update payout destination + claim with their own pubkey (POST).
+ *
+ * Authorization model: knowledge of the invite token is the credential. Once
+ * claimed (affiliate_pubkey set), updates require the same pubkey to be
+ * supplied in the body — the invite token effectively becomes a personal
+ * settings URL the affiliate keeps private.
+ */
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  if (!applyRateLimit(req, res, "affiliates-claim", RATE_LIMIT)) return;
+
+  try {
+    if (req.method === "GET") {
+      const { token } = req.query;
+      if (!token || typeof token !== "string") {
+        return res.status(400).json({ error: "token required" });
+      }
+      const a = await getAffiliateByInviteToken(token);
+      if (!a) return res.status(404).json({ error: "Invite not found" });
+      return res.status(200).json({
+        id: a.id,
+        seller_pubkey: a.seller_pubkey,
+        name: a.name,
+        email: a.email,
+        affiliate_pubkey: a.affiliate_pubkey,
+        invite_claimed_at: a.invite_claimed_at,
+        lightning_address: a.lightning_address,
+        stripe_account_id: a.stripe_account_id,
+      });
+    }
+
+    if (req.method === "POST") {
+      const { token, affiliatePubkey, lightningAddress, stripeAccountId } =
+        req.body ?? {};
+      if (!token) return res.status(400).json({ error: "token required" });
+      const existing = await getAffiliateByInviteToken(String(token));
+      if (!existing) return res.status(404).json({ error: "Invite not found" });
+      if (
+        existing.affiliate_pubkey &&
+        affiliatePubkey &&
+        existing.affiliate_pubkey !== affiliatePubkey
+      ) {
+        return res
+          .status(403)
+          .json({ error: "Invite already claimed by another pubkey" });
+      }
+      const updated = await updateAffiliatePayoutMethod(String(token), {
+        affiliatePubkey: affiliatePubkey ?? existing.affiliate_pubkey ?? null,
+        lightningAddress: lightningAddress ?? null,
+        stripeAccountId: stripeAccountId ?? null,
+      });
+      return res.status(200).json(updated);
+    }
+
+    return res.status(405).json({ error: "Method not allowed" });
+  } catch (err) {
+    console.error("affiliates/claim error:", err);
+    return res.status(500).json({ error: "Internal error" });
+  }
+}

--- a/pages/api/affiliates/click-stats.ts
+++ b/pages/api/affiliates/click-stats.ts
@@ -1,0 +1,45 @@
+/**
+ * Per-code click + conversion aggregates for a seller. Same Nostr-signed
+ * proof scope as the affiliates list since both are read-only, seller-scoped
+ * stats.
+ */
+import type { NextApiRequest, NextApiResponse } from "next";
+import { getAffiliateClickStats } from "@/utils/db/affiliates";
+import {
+  buildAffiliateClickStatsProof,
+  extractSignedEventFromRequest,
+  verifySignedHttpRequestProof,
+} from "@/utils/nostr/request-auth";
+import { applyRateLimit } from "@/utils/rate-limit";
+
+const RATE_LIMIT = { limit: 60, windowMs: 60 * 1000 };
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  if (req.method !== "GET") {
+    return res.status(405).json({ error: "Method not allowed" });
+  }
+  if (!applyRateLimit(req, res, "affiliates-click-stats", RATE_LIMIT)) return;
+
+  const { pubkey, sinceDays } = req.query;
+  if (!pubkey || typeof pubkey !== "string") {
+    return res.status(400).json({ error: "pubkey required" });
+  }
+  const days = Math.min(365, Math.max(1, sinceDays ? Number(sinceDays) : 30));
+
+  const v = verifySignedHttpRequestProof(
+    extractSignedEventFromRequest(req),
+    buildAffiliateClickStatsProof(pubkey)
+  );
+  if (!v.ok) return res.status(v.status).json({ error: v.error });
+
+  try {
+    const stats = await getAffiliateClickStats(pubkey, days);
+    return res.status(200).json({ sinceDays: days, stats });
+  } catch (err) {
+    console.error("affiliates/click-stats error:", err);
+    return res.status(500).json({ error: "Internal error" });
+  }
+}

--- a/pages/api/affiliates/codes.ts
+++ b/pages/api/affiliates/codes.ts
@@ -81,7 +81,7 @@ export default async function handler(
         buyerDiscountType: buyerDiscountType ?? "percent",
         buyerDiscountValue: Number(buyerDiscountValue ?? 0),
         currency: currency ?? null,
-        payoutSchedule: payoutSchedule ?? "every_sale",
+        payoutSchedule: payoutSchedule ?? "monthly",
         expiration: expiration ? Number(expiration) : null,
         maxUses: maxUses ? Number(maxUses) : null,
       });

--- a/pages/api/affiliates/codes.ts
+++ b/pages/api/affiliates/codes.ts
@@ -1,0 +1,125 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import {
+  createAffiliateCode,
+  deleteAffiliateCode,
+  listAffiliateCodesBySeller,
+  updateAffiliateCode,
+} from "@/utils/db/affiliates";
+import {
+  buildAffiliateCodeCreateProof,
+  buildAffiliateCodeDeleteProof,
+  buildAffiliateCodeUpdateProof,
+  buildAffiliateCodesListProof,
+  extractSignedEventFromRequest,
+  verifySignedHttpRequestProof,
+} from "@/utils/nostr/request-auth";
+import { applyRateLimit } from "@/utils/rate-limit";
+
+const RATE_LIMIT = { limit: 120, windowMs: 60 * 1000 };
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  if (!applyRateLimit(req, res, "affiliates-codes", RATE_LIMIT)) return;
+
+  try {
+    if (req.method === "GET") {
+      const { pubkey } = req.query;
+      if (!pubkey || typeof pubkey !== "string") {
+        return res.status(400).json({ error: "pubkey required" });
+      }
+      const v = verifySignedHttpRequestProof(
+        extractSignedEventFromRequest(req),
+        buildAffiliateCodesListProof(pubkey)
+      );
+      if (!v.ok) return res.status(v.status).json({ error: v.error });
+      const rows = await listAffiliateCodesBySeller(pubkey);
+      return res.status(200).json(rows);
+    }
+
+    if (req.method === "POST") {
+      const {
+        pubkey,
+        affiliateId,
+        code,
+        rebateType,
+        rebateValue,
+        buyerDiscountType,
+        buyerDiscountValue,
+        currency,
+        payoutSchedule,
+        expiration,
+        maxUses,
+      } = req.body ?? {};
+      if (
+        !pubkey ||
+        !affiliateId ||
+        !code ||
+        !rebateType ||
+        rebateValue == null
+      ) {
+        return res.status(400).json({ error: "Missing required fields" });
+      }
+      const normalized = String(code).trim().toUpperCase();
+      const v = verifySignedHttpRequestProof(
+        extractSignedEventFromRequest(req),
+        buildAffiliateCodeCreateProof({
+          pubkey,
+          affiliateId: Number(affiliateId),
+          code: normalized,
+        })
+      );
+      if (!v.ok) return res.status(v.status).json({ error: v.error });
+
+      const created = await createAffiliateCode({
+        affiliateId: Number(affiliateId),
+        sellerPubkey: pubkey,
+        code: normalized,
+        rebateType,
+        rebateValue: Number(rebateValue),
+        buyerDiscountType: buyerDiscountType ?? "percent",
+        buyerDiscountValue: Number(buyerDiscountValue ?? 0),
+        currency: currency ?? null,
+        payoutSchedule: payoutSchedule ?? "every_sale",
+        expiration: expiration ? Number(expiration) : null,
+        maxUses: maxUses ? Number(maxUses) : null,
+      });
+      return res.status(200).json(created);
+    }
+
+    if (req.method === "PATCH") {
+      const { pubkey, codeId, ...patch } = req.body ?? {};
+      if (!pubkey || !codeId) {
+        return res.status(400).json({ error: "pubkey and codeId required" });
+      }
+      const v = verifySignedHttpRequestProof(
+        extractSignedEventFromRequest(req),
+        buildAffiliateCodeUpdateProof({ pubkey, codeId: Number(codeId) })
+      );
+      if (!v.ok) return res.status(v.status).json({ error: v.error });
+      const updated = await updateAffiliateCode(Number(codeId), pubkey, patch);
+      if (!updated) return res.status(404).json({ error: "Not found" });
+      return res.status(200).json(updated);
+    }
+
+    if (req.method === "DELETE") {
+      const { pubkey, codeId } = req.body ?? {};
+      if (!pubkey || !codeId) {
+        return res.status(400).json({ error: "pubkey and codeId required" });
+      }
+      const v = verifySignedHttpRequestProof(
+        extractSignedEventFromRequest(req),
+        buildAffiliateCodeDeleteProof({ pubkey, codeId: Number(codeId) })
+      );
+      if (!v.ok) return res.status(v.status).json({ error: v.error });
+      await deleteAffiliateCode(Number(codeId), pubkey);
+      return res.status(200).json({ success: true });
+    }
+
+    return res.status(405).json({ error: "Method not allowed" });
+  } catch (err) {
+    console.error("affiliates/codes error:", err);
+    return res.status(500).json({ error: "Internal error" });
+  }
+}

--- a/pages/api/affiliates/manage.ts
+++ b/pages/api/affiliates/manage.ts
@@ -1,0 +1,115 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import {
+  createAffiliate,
+  deleteAffiliate,
+  listAffiliatesBySeller,
+  updateAffiliate,
+} from "@/utils/db/affiliates";
+import {
+  buildAffiliateCreateProof,
+  buildAffiliateDeleteProof,
+  buildAffiliateUpdateProof,
+  buildAffiliatesListProof,
+  extractSignedEventFromRequest,
+  verifySignedHttpRequestProof,
+} from "@/utils/nostr/request-auth";
+import { applyRateLimit } from "@/utils/rate-limit";
+
+const RATE_LIMIT = { limit: 60, windowMs: 60 * 1000 };
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  if (!applyRateLimit(req, res, "affiliates-manage", RATE_LIMIT)) return;
+
+  try {
+    if (req.method === "GET") {
+      const { pubkey } = req.query;
+      if (!pubkey || typeof pubkey !== "string") {
+        return res.status(400).json({ error: "pubkey required" });
+      }
+      const v = verifySignedHttpRequestProof(
+        extractSignedEventFromRequest(req),
+        buildAffiliatesListProof(pubkey)
+      );
+      if (!v.ok) return res.status(v.status).json({ error: v.error });
+      const rows = await listAffiliatesBySeller(pubkey);
+      return res.status(200).json(rows);
+    }
+
+    if (req.method === "POST") {
+      const { pubkey, name, email, lightningAddress, stripeAccountId, notes } =
+        req.body ?? {};
+      if (!pubkey || !name) {
+        return res.status(400).json({ error: "pubkey and name required" });
+      }
+      const v = verifySignedHttpRequestProof(
+        extractSignedEventFromRequest(req),
+        buildAffiliateCreateProof({ pubkey, name })
+      );
+      if (!v.ok) return res.status(v.status).json({ error: v.error });
+      const created = await createAffiliate({
+        sellerPubkey: pubkey,
+        name,
+        email: email ?? null,
+        lightningAddress: lightningAddress ?? null,
+        stripeAccountId: stripeAccountId ?? null,
+        notes: notes ?? null,
+      });
+      return res.status(200).json(created);
+    }
+
+    if (req.method === "PATCH") {
+      const {
+        pubkey,
+        affiliateId,
+        name,
+        email,
+        lightningAddress,
+        stripeAccountId,
+        notes,
+      } = req.body ?? {};
+      if (!pubkey || !affiliateId) {
+        return res
+          .status(400)
+          .json({ error: "pubkey and affiliateId required" });
+      }
+      const v = verifySignedHttpRequestProof(
+        extractSignedEventFromRequest(req),
+        buildAffiliateUpdateProof({ pubkey, affiliateId: Number(affiliateId) })
+      );
+      if (!v.ok) return res.status(v.status).json({ error: v.error });
+      const updated = await updateAffiliate(Number(affiliateId), pubkey, {
+        name,
+        email,
+        lightningAddress,
+        stripeAccountId,
+        notes,
+      });
+      if (!updated) return res.status(404).json({ error: "Not found" });
+      return res.status(200).json(updated);
+    }
+
+    if (req.method === "DELETE") {
+      const { pubkey, affiliateId } = req.body ?? {};
+      if (!pubkey || !affiliateId) {
+        return res
+          .status(400)
+          .json({ error: "pubkey and affiliateId required" });
+      }
+      const v = verifySignedHttpRequestProof(
+        extractSignedEventFromRequest(req),
+        buildAffiliateDeleteProof({ pubkey, affiliateId: Number(affiliateId) })
+      );
+      if (!v.ok) return res.status(v.status).json({ error: v.error });
+      await deleteAffiliate(Number(affiliateId), pubkey);
+      return res.status(200).json({ success: true });
+    }
+
+    return res.status(405).json({ error: "Method not allowed" });
+  } catch (err) {
+    console.error("affiliates/manage error:", err);
+    return res.status(500).json({ error: "Internal error" });
+  }
+}

--- a/pages/api/affiliates/manage.ts
+++ b/pages/api/affiliates/manage.ts
@@ -3,6 +3,8 @@ import {
   createAffiliate,
   deleteAffiliate,
   listAffiliatesBySeller,
+  regenerateInviteToken,
+  setAffiliatePayoutsEnabled,
   updateAffiliate,
 } from "@/utils/db/affiliates";
 import {
@@ -92,7 +94,7 @@ export default async function handler(
     }
 
     if (req.method === "DELETE") {
-      const { pubkey, affiliateId } = req.body ?? {};
+      const { pubkey, affiliateId, force } = req.body ?? {};
       if (!pubkey || !affiliateId) {
         return res
           .status(400)
@@ -103,8 +105,53 @@ export default async function handler(
         buildAffiliateDeleteProof({ pubkey, affiliateId: Number(affiliateId) })
       );
       if (!v.ok) return res.status(v.status).json({ error: v.error });
-      await deleteAffiliate(Number(affiliateId), pubkey);
+      try {
+        await deleteAffiliate(Number(affiliateId), pubkey, {
+          force: Boolean(force),
+        });
+      } catch (e) {
+        // Surface the human-readable "unsettled balance" guard as a 409 so
+        // the UI can prompt the seller for confirmation + force.
+        const msg = e instanceof Error ? e.message : "Delete failed";
+        if (msg.includes("unsettled balance")) {
+          return res.status(409).json({ error: msg });
+        }
+        throw e;
+      }
       return res.status(200).json({ success: true });
+    }
+
+    // PUT: side-channel mutations that don't fit a CRUD verb cleanly. Reuses
+    // the affiliate-update proof since both rotate-token and toggle-payouts
+    // require the same authority (seller controls this affiliate).
+    if (req.method === "PUT") {
+      const { pubkey, affiliateId, action, enabled } = req.body ?? {};
+      if (!pubkey || !affiliateId || !action) {
+        return res
+          .status(400)
+          .json({ error: "pubkey, affiliateId and action required" });
+      }
+      const v = verifySignedHttpRequestProof(
+        extractSignedEventFromRequest(req),
+        buildAffiliateUpdateProof({ pubkey, affiliateId: Number(affiliateId) })
+      );
+      if (!v.ok) return res.status(v.status).json({ error: v.error });
+
+      if (action === "regenerate-invite-token") {
+        const token = await regenerateInviteToken(Number(affiliateId), pubkey);
+        if (!token) return res.status(404).json({ error: "Not found" });
+        return res.status(200).json({ invite_token: token });
+      }
+      if (action === "set-payouts-enabled") {
+        const updated = await setAffiliatePayoutsEnabled(
+          Number(affiliateId),
+          pubkey,
+          Boolean(enabled)
+        );
+        if (!updated) return res.status(404).json({ error: "Not found" });
+        return res.status(200).json(updated);
+      }
+      return res.status(400).json({ error: "Unknown action" });
     }
 
     return res.status(405).json({ error: "Method not allowed" });

--- a/pages/api/affiliates/mark-paid.ts
+++ b/pages/api/affiliates/mark-paid.ts
@@ -1,0 +1,92 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import {
+  createPayoutAndSettle,
+  getAffiliateById,
+  getPayableReferralBundle,
+  markReferralsPayableBySchedule,
+} from "@/utils/db/affiliates";
+import {
+  buildAffiliateMarkPaidProof,
+  extractSignedEventFromRequest,
+  verifySignedHttpRequestProof,
+} from "@/utils/nostr/request-auth";
+import { applyRateLimit } from "@/utils/rate-limit";
+
+const RATE_LIMIT = { limit: 60, windowMs: 60 * 1000 };
+
+/**
+ * Seller marks a pending balance as settled out-of-band (cash, off-platform
+ * transfer, etc). Pulls eligible referrals into a single payout record.
+ */
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  if (req.method !== "POST") {
+    return res.status(405).json({ error: "Method not allowed" });
+  }
+  if (!applyRateLimit(req, res, "affiliates-mark-paid", RATE_LIMIT)) return;
+
+  try {
+    const { pubkey, affiliateId, amountSmallest, currency, note } =
+      req.body ?? {};
+    if (!pubkey || !affiliateId || amountSmallest == null || !currency) {
+      return res.status(400).json({ error: "Missing required fields" });
+    }
+    const v = verifySignedHttpRequestProof(
+      extractSignedEventFromRequest(req),
+      buildAffiliateMarkPaidProof({
+        pubkey,
+        affiliateId: Number(affiliateId),
+        amountSmallest: Number(amountSmallest),
+        currency,
+      })
+    );
+    if (!v.ok) return res.status(v.status).json({ error: v.error });
+
+    const affiliate = await getAffiliateById(Number(affiliateId));
+    if (!affiliate || affiliate.seller_pubkey !== pubkey) {
+      return res.status(404).json({ error: "Affiliate not found" });
+    }
+
+    // Promote everything pending -> payable so we can settle it as one batch.
+    // This is a best-effort: we reuse the by-schedule helper across all cadences
+    // because a manual mark-paid implicitly covers anything still pending.
+    for (const sched of ["every_sale", "daily", "weekly", "monthly"] as const) {
+      await markReferralsPayableBySchedule(sched);
+    }
+
+    const bundles = await getPayableReferralBundle(Number(affiliateId));
+    const matchingBundle = bundles.find((b) => b.currency === currency);
+    if (!matchingBundle) {
+      return res.status(400).json({ error: "No payable balance for currency" });
+    }
+
+    const totalSmallest = Number(matchingBundle.total_smallest);
+    if (Number(amountSmallest) > totalSmallest) {
+      return res.status(400).json({
+        error: `Requested amount exceeds payable balance (${totalSmallest})`,
+      });
+    }
+
+    // We currently settle the entire bundle when the seller marks paid; partial
+    // payouts would require splitting referrals, which is intentionally
+    // out-of-scope for the manual workflow.
+    const { payoutId } = await createPayoutAndSettle({
+      affiliateId: Number(affiliateId),
+      sellerPubkey: pubkey,
+      method: "manual",
+      amountSmallest: totalSmallest,
+      currency,
+      note: note ?? null,
+      referralIds: matchingBundle.referral_ids,
+    });
+
+    return res
+      .status(200)
+      .json({ success: true, payoutId, settledSmallest: totalSmallest });
+  } catch (err) {
+    console.error("affiliates/mark-paid error:", err);
+    return res.status(500).json({ error: "Internal error" });
+  }
+}

--- a/pages/api/affiliates/mark-paid.ts
+++ b/pages/api/affiliates/mark-paid.ts
@@ -52,7 +52,7 @@ export default async function handler(
     // Promote everything pending -> payable so we can settle it as one batch.
     // This is a best-effort: we reuse the by-schedule helper across all cadences
     // because a manual mark-paid implicitly covers anything still pending.
-    for (const sched of ["every_sale", "daily", "weekly", "monthly"] as const) {
+    for (const sched of ["weekly", "biweekly", "monthly"] as const) {
       await markReferralsPayableBySchedule(sched);
     }
 

--- a/pages/api/affiliates/payouts.ts
+++ b/pages/api/affiliates/payouts.ts
@@ -1,0 +1,46 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import {
+  getAffiliateBalances,
+  listPayoutsBySeller,
+  listReferralsBySeller,
+} from "@/utils/db/affiliates";
+import {
+  buildAffiliatePayoutsListProof,
+  extractSignedEventFromRequest,
+  verifySignedHttpRequestProof,
+} from "@/utils/nostr/request-auth";
+import { applyRateLimit } from "@/utils/rate-limit";
+
+const RATE_LIMIT = { limit: 60, windowMs: 60 * 1000 };
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  if (req.method !== "GET") {
+    return res.status(405).json({ error: "Method not allowed" });
+  }
+  if (!applyRateLimit(req, res, "affiliates-payouts", RATE_LIMIT)) return;
+
+  try {
+    const { pubkey } = req.query;
+    if (!pubkey || typeof pubkey !== "string") {
+      return res.status(400).json({ error: "pubkey required" });
+    }
+    const v = verifySignedHttpRequestProof(
+      extractSignedEventFromRequest(req),
+      buildAffiliatePayoutsListProof(pubkey)
+    );
+    if (!v.ok) return res.status(v.status).json({ error: v.error });
+
+    const [balances, payouts, referrals] = await Promise.all([
+      getAffiliateBalances(pubkey),
+      listPayoutsBySeller(pubkey),
+      listReferralsBySeller(pubkey),
+    ]);
+    return res.status(200).json({ balances, payouts, referrals });
+  } catch (err) {
+    console.error("affiliates/payouts error:", err);
+    return res.status(500).json({ error: "Internal error" });
+  }
+}

--- a/pages/api/affiliates/process-payouts.ts
+++ b/pages/api/affiliates/process-payouts.ts
@@ -1,15 +1,99 @@
 import type { NextApiRequest, NextApiResponse } from "next";
+import { assertAffiliateUnsubscribeSecretConfigured } from "@/utils/email/unsubscribe-tokens";
+import { createHash } from "crypto";
 import Stripe from "stripe";
 import { LightningAddress } from "@getalby/lightning-tools";
 import {
+  clearPayoutFailure,
   createPayoutAndSettle,
   getAffiliateById,
   getPayableReferralBundle,
+  getSellerEmailForPubkey,
+  MAX_PAYOUT_FAILURES,
   markReferralsPayableBySchedule,
   PayoutSchedule,
+  recordPayoutFailure,
+  tryAdvisoryLock,
 } from "@/utils/db/affiliates";
+import {
+  sendAffiliatePaidEmail,
+  sendAffiliatePausedToAffiliate,
+  sendAffiliatePausedToSeller,
+} from "@/utils/email/email-service";
+import { buildAffiliateUnsubscribeUrl } from "@/utils/email/unsubscribe-tokens";
+
+function publicBaseUrl(): string {
+  return (
+    process.env.NEXT_PUBLIC_BASE_URL ||
+    (process.env.REPLIT_DEV_DOMAIN
+      ? `https://${process.env.REPLIT_DEV_DOMAIN}`
+      : "http://localhost:3000")
+  );
+}
+
+function unsubUrlFor(affiliateId: number): string | null {
+  try {
+    return buildAffiliateUnsubscribeUrl(publicBaseUrl(), affiliateId);
+  } catch {
+    // Missing AFFILIATE_UNSUBSCRIBE_SECRET — skip the header; mail still
+    // sends but without a one-click unsubscribe footer.
+    return null;
+  }
+}
+
+// Stable Stripe idempotency key for a (affiliate, currency, bundle) tuple so
+// that retries after a transient failure don't double-pay. We hash the sorted
+// referral IDs along with the amount + currency: any two runs that try to
+// settle the exact same set of referrals will produce the exact same key,
+// which makes Stripe return the original transfer instead of creating a new
+// one. We deliberately *don't* include a timestamp here.
+function stableStripePayoutIdempotencyKey(params: {
+  affiliateId: number;
+  currency: string;
+  amountSmallest: number;
+  referralIds: number[];
+}): string {
+  const ids = [...params.referralIds].sort((a, b) => a - b).join(",");
+  const digest = createHash("sha256")
+    .update(
+      `${params.affiliateId}|${params.currency.toLowerCase()}|${params.amountSmallest}|${ids}`
+    )
+    .digest("hex")
+    .slice(0, 32);
+  return `aff-payout-${params.affiliateId}-${digest}`;
+}
+
+// Per-affiliate advisory-lock key: stable namespace at 92_000_000+id so it
+// can't collide with the per-schedule keys (91_00x).
+function affiliateLockKey(affiliateId: number): number {
+  return 92_000_000 + affiliateId;
+}
+
+// Stable advisory-lock keys per schedule so concurrent cron invocations on
+// the same cadence cannot double-pay. Picked arbitrarily; just need to be
+// distinct integers that no other lock holder uses.
+const ADVISORY_LOCK_KEYS: Record<PayoutSchedule, number> = {
+  weekly: 91_001,
+  biweekly: 91_002,
+  monthly: 91_003,
+};
+
+// Defensive minimum payout per currency. Sub-cent / sub-sat payouts cost
+// more in fees and noise than they're worth and small rebates pile up
+// quickly when codes are spammed.
+const MIN_PAYOUT_SMALLEST: Record<string, number> = {
+  sats: 100, // 100 sats
+};
+function minPayoutFor(currency: string): number {
+  return MIN_PAYOUT_SMALLEST[currency.toLowerCase()] ?? 50; // 50 cents fiat
+}
 import { getDbPool } from "@/utils/db/db-service";
 import { applyRateLimit } from "@/utils/rate-limit";
+
+// Fail the deploy fast if the unsubscribe secret is missing in prod —
+// otherwise affiliate emails go out without `List-Unsubscribe` headers and
+// Gmail/Yahoo will start spam-foldering them silently.
+assertAffiliateUnsubscribeSecretConfigured();
 
 const RATE_LIMIT = { limit: 12, windowMs: 60 * 1000 };
 
@@ -50,15 +134,30 @@ export default async function handler(
     return res.status(401).json({ error: "Unauthorized" });
   }
 
+  let lock: { release: () => Promise<void> } | null = null;
   try {
-    const schedule = (req.query.schedule as string) || "daily";
-    if (!["every_sale", "daily", "weekly", "monthly"].includes(schedule)) {
+    const schedule = (req.query.schedule as string) || "monthly";
+    if (!["weekly", "biweekly", "monthly"].includes(schedule)) {
       return res.status(400).json({ error: "Invalid schedule" });
+    }
+    const dryRun = req.query.dryRun === "1" || req.query.dryRun === "true";
+
+    // Per-schedule advisory lock: refuse the run if another worker is
+    // already inside this cadence's payout loop.
+    lock = await tryAdvisoryLock(
+      ADVISORY_LOCK_KEYS[schedule as PayoutSchedule]
+    );
+    if (!lock) {
+      return res.status(409).json({
+        error: "Another payout run is already in progress for this schedule",
+      });
     }
 
     // 1. Promote all pending referrals on this schedule to "payable" so they
-    //    show up in the bundle.
-    await markReferralsPayableBySchedule(schedule as PayoutSchedule);
+    //    show up in the bundle. Skipped in dry-run so we don't change state.
+    if (!dryRun) {
+      await markReferralsPayableBySchedule(schedule as PayoutSchedule);
+    }
 
     // 2. Walk every affiliate that has any payable balance and try to settle.
     const pool = getDbPool();
@@ -87,111 +186,329 @@ export default async function handler(
       const affiliate = await getAffiliateById(affiliateId);
       if (!affiliate) continue;
 
-      const bundles = await getPayableReferralBundle(affiliateId);
-      for (const bundle of bundles) {
-        const total = Number(bundle.total_smallest);
-        if (total <= 0) continue;
+      // Honor the seller's kill-switch + the auto-disable from repeated
+      // failures. The seller can re-enable from the dashboard once they've
+      // fixed the underlying issue (wrong LN address, dead Stripe account).
+      if (!affiliate.payouts_enabled) {
+        results.push({
+          affiliateId,
+          currency: "*",
+          method: "manual",
+          success: false,
+          error: affiliate.last_payout_failure_reason
+            ? `Payouts disabled (last failure: ${affiliate.last_payout_failure_reason})`
+            : "Payouts disabled by seller",
+        });
+        continue;
+      }
 
-        // Pick the right rail per bundle currency. Sats stay on lightning.
-        // Fiat goes through Stripe Connect when configured.
-        const isSats = bundle.currency.toLowerCase() === "sats";
-        const useLightning = isSats && !!affiliate.lightning_address;
-        const useStripe =
-          !isSats &&
-          !!affiliate.stripe_account_id &&
-          !!process.env.STRIPE_SECRET_KEY;
+      // Per-affiliate lock so two cron invocations attacking different
+      // schedules can't both try to settle the same affiliate's bundles
+      // concurrently. Skip cleanly if another worker is already in this
+      // affiliate's loop.
+      const affLock = await tryAdvisoryLock(affiliateLockKey(affiliateId));
+      if (!affLock) {
+        results.push({
+          affiliateId,
+          currency: "*",
+          method: "manual",
+          success: false,
+          error: "Affiliate is being processed by another worker",
+        });
+        continue;
+      }
 
-        if (useLightning) {
-          try {
-            const ln = new LightningAddress(affiliate.lightning_address!);
-            await ln.fetch();
-            const invoice = await ln.requestInvoice({ satoshi: total });
-            // The platform itself does not (yet) hold a hot wallet here; we
-            // record the invoice id as the external_ref and mark the payout
-            // as paid only when the seller's NWC actually settles it. For
-            // now, store the bolt11 and let the seller pay it out-of-band
-            // by clicking "Mark paid" with the invoice as a note.
+      try {
+        const bundles = await getPayableReferralBundle(affiliateId);
+        for (const bundle of bundles) {
+          const total = Number(bundle.total_smallest);
+          if (total <= 0) continue;
+          if (total < minPayoutFor(bundle.currency)) {
             results.push({
               affiliateId,
               currency: bundle.currency,
-              method: "lightning",
+              method: "manual",
               success: false,
-              error: `Lightning payout requires manual settlement; invoice: ${invoice.paymentRequest}`,
-            });
-          } catch (err) {
-            results.push({
-              affiliateId,
-              currency: bundle.currency,
-              method: "lightning",
-              success: false,
-              error:
-                err instanceof Error
-                  ? err.message
-                  : "Lightning invoice fetch failed",
-            });
-          }
-        } else if (useStripe) {
-          try {
-            const transfer = await stripe.transfers.create(
-              {
-                amount: total,
-                currency: bundle.currency.toLowerCase(),
-                destination: affiliate.stripe_account_id!,
-                metadata: {
-                  affiliateId: String(affiliateId),
-                  scheduledPayout: "true",
-                  schedule,
-                },
-              },
-              {
-                idempotencyKey: `affiliate-payout-${affiliateId}-${Date.now()}`,
-              }
-            );
-            const { payoutId } = await createPayoutAndSettle({
-              affiliateId,
-              sellerPubkey: bundle.seller_pubkey,
-              method: "stripe",
               amountSmallest: total,
-              currency: bundle.currency,
-              externalRef: transfer.id,
-              referralIds: bundle.referral_ids,
+              error: `Below minimum payout (${minPayoutFor(bundle.currency)})`,
             });
+            continue;
+          }
+
+          // Pick the right rail per bundle currency. Sats stay on lightning.
+          // Fiat goes through Stripe Connect when configured.
+          const isSats = bundle.currency.toLowerCase() === "sats";
+          const useLightning = isSats && !!affiliate.lightning_address;
+          const useStripe =
+            !isSats &&
+            !!affiliate.stripe_account_id &&
+            !!process.env.STRIPE_SECRET_KEY;
+
+          if (dryRun) {
             results.push({
               affiliateId,
               currency: bundle.currency,
-              method: "stripe",
+              method: useLightning
+                ? "lightning"
+                : useStripe
+                  ? "stripe"
+                  : "manual",
               success: true,
               amountSmallest: total,
-              payoutId,
             });
-          } catch (err) {
+            continue;
+          }
+
+          if (useLightning) {
+            try {
+              const ln = new LightningAddress(affiliate.lightning_address!);
+              await ln.fetch();
+              const invoice = await ln.requestInvoice({ satoshi: total });
+              // The platform itself does not (yet) hold a hot wallet here; we
+              // record the invoice id as the external_ref and mark the payout
+              // as paid only when the seller's NWC actually settles it. For
+              // now, store the bolt11 and let the seller pay it out-of-band
+              // by clicking "Mark paid" with the invoice as a note. We do
+              // NOT count this as a failure for the auto-disable counter —
+              // the invoice was successfully fetched, settlement is just
+              // out-of-band.
+              results.push({
+                affiliateId,
+                currency: bundle.currency,
+                method: "lightning",
+                success: false,
+                error: `Lightning payout requires manual settlement; invoice: ${invoice.paymentRequest}`,
+              });
+            } catch (err) {
+              const reason =
+                err instanceof Error
+                  ? err.message
+                  : "Lightning invoice fetch failed";
+              await recordPayoutFailure(affiliateId, reason);
+              results.push({
+                affiliateId,
+                currency: bundle.currency,
+                method: "lightning",
+                success: false,
+                error: reason,
+              });
+            }
+          } else if (useStripe) {
+            try {
+              // Precheck the connected account is actually able to receive
+              // payouts before initiating a transfer that would otherwise be
+              // captured into Stripe limbo. We swallow lookup errors so a
+              // transient Stripe outage doesn't permanently block payouts.
+              try {
+                const acct = await stripe.accounts.retrieve(
+                  affiliate.stripe_account_id!
+                );
+                if (!acct.charges_enabled || !acct.payouts_enabled) {
+                  results.push({
+                    affiliateId,
+                    currency: bundle.currency,
+                    method: "stripe",
+                    success: false,
+                    amountSmallest: total,
+                    error:
+                      "Stripe account not ready (payouts_enabled is false)",
+                  });
+                  continue;
+                }
+              } catch (acctErr) {
+                console.warn(
+                  `Affiliate ${affiliateId} stripe account lookup failed:`,
+                  acctErr
+                );
+              }
+              const transfer = await stripe.transfers.create(
+                {
+                  amount: total,
+                  currency: bundle.currency.toLowerCase(),
+                  destination: affiliate.stripe_account_id!,
+                  metadata: {
+                    affiliateId: String(affiliateId),
+                    scheduledPayout: "true",
+                    schedule,
+                    // Embedding the bundle digest in metadata lets a human
+                    // operator find the matching DB row from a Stripe transfer.
+                    bundleKey: stableStripePayoutIdempotencyKey({
+                      affiliateId,
+                      currency: bundle.currency,
+                      amountSmallest: total,
+                      referralIds: bundle.referral_ids,
+                    }),
+                  },
+                },
+                {
+                  // Stable per-bundle key. If the cron crashes between a
+                  // successful transfer and the DB write below, the next run
+                  // will compute the same key, Stripe returns the original
+                  // transfer (no double-charge) and we then settle the
+                  // referrals locally on the retry.
+                  idempotencyKey: stableStripePayoutIdempotencyKey({
+                    affiliateId,
+                    currency: bundle.currency,
+                    amountSmallest: total,
+                    referralIds: bundle.referral_ids,
+                  }),
+                }
+              );
+              const { payoutId } = await createPayoutAndSettle({
+                affiliateId,
+                sellerPubkey: bundle.seller_pubkey,
+                method: "stripe",
+                amountSmallest: total,
+                currency: bundle.currency,
+                externalRef: transfer.id,
+                referralIds: bundle.referral_ids,
+              });
+              // Reset the failure counter on a clean success so a previously
+              // flaky affiliate doesn't stay one strike away from auto-off.
+              await clearPayoutFailure(affiliateId);
+              // Notify the affiliate by email (best-effort, non-blocking).
+              if (
+                affiliate.email &&
+                affiliate.email_notifications_enabled !== false
+              ) {
+                sendAffiliatePaidEmail(affiliate.email, {
+                  affiliateName: affiliate.name,
+                  amountSmallest: total,
+                  currency: bundle.currency,
+                  method: "stripe",
+                  externalRef: transfer.id,
+                  unsubscribeUrl: unsubUrlFor(affiliateId),
+                }).catch((e) =>
+                  console.warn(
+                    `affiliate paid email send failed for ${affiliateId}:`,
+                    e
+                  )
+                );
+              }
+              results.push({
+                affiliateId,
+                currency: bundle.currency,
+                method: "stripe",
+                success: true,
+                amountSmallest: total,
+                payoutId,
+              });
+            } catch (err) {
+              const reason =
+                err instanceof Error ? err.message : "Stripe transfer failed";
+              await recordPayoutFailure(affiliateId, reason);
+              // After recording, check whether this failure pushed us over
+              // the auto-pause threshold and notify both the affiliate and
+              // the seller exactly once at the moment of pause.
+              try {
+                const after = await getAffiliateById(affiliateId);
+                if (
+                  after &&
+                  !after.payouts_enabled &&
+                  after.payout_failure_count >= MAX_PAYOUT_FAILURES
+                ) {
+                  if (
+                    after.email &&
+                    after.email_notifications_enabled !== false
+                  ) {
+                    sendAffiliatePausedToAffiliate(after.email, {
+                      affiliateName: after.name,
+                      reason,
+                      unsubscribeUrl: unsubUrlFor(affiliateId),
+                    }).catch(() => {});
+                  }
+                  const sellerEmail = await getSellerEmailForPubkey(
+                    after.seller_pubkey
+                  );
+                  if (sellerEmail) {
+                    sendAffiliatePausedToSeller(sellerEmail, {
+                      affiliateName: after.name,
+                      reason,
+                      failureCount: after.payout_failure_count,
+                    }).catch(() => {});
+                  }
+                }
+              } catch (notifyErr) {
+                console.warn(
+                  `affiliate ${affiliateId} pause notification failed:`,
+                  notifyErr
+                );
+              }
+              results.push({
+                affiliateId,
+                currency: bundle.currency,
+                method: "stripe",
+                success: false,
+                error: reason,
+              });
+            }
+          } else {
+            // No payout method connected — accrue silently for the seller to
+            // settle out-of-band. Leave referrals in 'payable' so they show up
+            // on the seller dashboard as "ready to pay".
             results.push({
               affiliateId,
               currency: bundle.currency,
-              method: "stripe",
-              success: false,
-              error:
-                err instanceof Error ? err.message : "Stripe transfer failed",
+              method: "manual",
+              success: true,
+              amountSmallest: total,
             });
           }
-        } else {
-          // No payout method connected — accrue silently for the seller to
-          // settle out-of-band. Leave referrals in 'payable' so they show up
-          // on the seller dashboard as "ready to pay".
-          results.push({
-            affiliateId,
-            currency: bundle.currency,
-            method: "manual",
-            success: true,
-            amountSmallest: total,
-          });
+        }
+      } finally {
+        try {
+          await affLock.release();
+        } catch (e) {
+          console.warn(`affiliate ${affiliateId} lock release failed:`, e);
         }
       }
     }
 
-    return res.status(200).json({ schedule, processed: results });
+    // Structured summary line so log aggregation / alerting can spot
+    // failure spikes without parsing the per-row JSON blob.
+    const successCount = results.filter((r) => r.success).length;
+    const failureCount = results.length - successCount;
+    const totalSettled = results
+      .filter((r) => r.success && typeof r.amountSmallest === "number")
+      .reduce((acc, r) => acc + (r.amountSmallest ?? 0), 0);
+    console.log(
+      `AFFILIATE_PAYOUT_RUN schedule=${schedule} dryRun=${dryRun} ` +
+        `affiliates=${affiliateIds.length} bundles=${results.length} ` +
+        `success=${successCount} failure=${failureCount} ` +
+        `totalSettled=${totalSettled}`
+    );
+    for (const r of results.filter((x) => !x.success)) {
+      console.warn(
+        `AFFILIATE_PAYOUT_FAILURE affiliateId=${r.affiliateId} ` +
+          `currency=${r.currency} method=${r.method} ` +
+          `amount=${r.amountSmallest ?? 0} reason=${JSON.stringify(
+            r.error ?? ""
+          )}`
+      );
+    }
+
+    return res.status(200).json({
+      schedule,
+      dryRun,
+      processed: results,
+      summary: {
+        affiliates: affiliateIds.length,
+        bundles: results.length,
+        success: successCount,
+        failure: failureCount,
+        totalSettled,
+      },
+    });
   } catch (err) {
     console.error("affiliates/process-payouts error:", err);
     return res.status(500).json({ error: "Internal error" });
+  } finally {
+    if (lock) {
+      try {
+        await lock.release();
+      } catch (e) {
+        console.warn("advisory lock release failed:", e);
+      }
+    }
   }
 }

--- a/pages/api/affiliates/process-payouts.ts
+++ b/pages/api/affiliates/process-payouts.ts
@@ -1,0 +1,197 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import Stripe from "stripe";
+import { LightningAddress } from "@getalby/lightning-tools";
+import {
+  createPayoutAndSettle,
+  getAffiliateById,
+  getPayableReferralBundle,
+  markReferralsPayableBySchedule,
+  PayoutSchedule,
+} from "@/utils/db/affiliates";
+import { getDbPool } from "@/utils/db/db-service";
+import { applyRateLimit } from "@/utils/rate-limit";
+
+const RATE_LIMIT = { limit: 12, windowMs: 60 * 1000 };
+
+const stripe = new Stripe(process.env.STRIPE_SECRET_KEY || "", {
+  apiVersion: "2025-09-30.clover",
+});
+
+/**
+ * Cron-driven affiliate payout processor.
+ *
+ * Trigger by cron (e.g. once per hour) with `?schedule=daily|weekly|monthly`.
+ * `every_sale` is normally handled inline by the Stripe transfer hook, but
+ * any leftover (e.g. bitcoin orders without an inline LN payout) will also
+ * be picked up here.
+ *
+ * Authorization: requires the `AFFILIATE_PAYOUT_CRON_SECRET` env to match
+ * an `Authorization: Bearer ...` header. This keeps the endpoint usable from
+ * scheduler infrastructure without requiring a Nostr signature.
+ */
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  if (req.method !== "POST") {
+    return res.status(405).json({ error: "Method not allowed" });
+  }
+  if (!applyRateLimit(req, res, "affiliates-process-payouts", RATE_LIMIT))
+    return;
+
+  const expected = process.env.AFFILIATE_PAYOUT_CRON_SECRET;
+  if (!expected) {
+    return res
+      .status(500)
+      .json({ error: "AFFILIATE_PAYOUT_CRON_SECRET not configured" });
+  }
+  const authHeader = req.headers.authorization || "";
+  if (authHeader !== `Bearer ${expected}`) {
+    return res.status(401).json({ error: "Unauthorized" });
+  }
+
+  try {
+    const schedule = (req.query.schedule as string) || "daily";
+    if (!["every_sale", "daily", "weekly", "monthly"].includes(schedule)) {
+      return res.status(400).json({ error: "Invalid schedule" });
+    }
+
+    // 1. Promote all pending referrals on this schedule to "payable" so they
+    //    show up in the bundle.
+    await markReferralsPayableBySchedule(schedule as PayoutSchedule);
+
+    // 2. Walk every affiliate that has any payable balance and try to settle.
+    const pool = getDbPool();
+    const client = await pool.connect();
+    let affiliateIds: number[] = [];
+    try {
+      const r = await client.query(
+        `SELECT DISTINCT affiliate_id FROM affiliate_referrals WHERE status = 'payable'`
+      );
+      affiliateIds = r.rows.map((row) => row.affiliate_id as number);
+    } finally {
+      client.release();
+    }
+
+    const results: Array<{
+      affiliateId: number;
+      currency: string;
+      method: string;
+      success: boolean;
+      amountSmallest?: number;
+      payoutId?: number;
+      error?: string;
+    }> = [];
+
+    for (const affiliateId of affiliateIds) {
+      const affiliate = await getAffiliateById(affiliateId);
+      if (!affiliate) continue;
+
+      const bundles = await getPayableReferralBundle(affiliateId);
+      for (const bundle of bundles) {
+        const total = Number(bundle.total_smallest);
+        if (total <= 0) continue;
+
+        // Pick the right rail per bundle currency. Sats stay on lightning.
+        // Fiat goes through Stripe Connect when configured.
+        const isSats = bundle.currency.toLowerCase() === "sats";
+        const useLightning = isSats && !!affiliate.lightning_address;
+        const useStripe =
+          !isSats &&
+          !!affiliate.stripe_account_id &&
+          !!process.env.STRIPE_SECRET_KEY;
+
+        if (useLightning) {
+          try {
+            const ln = new LightningAddress(affiliate.lightning_address!);
+            await ln.fetch();
+            const invoice = await ln.requestInvoice({ satoshi: total });
+            // The platform itself does not (yet) hold a hot wallet here; we
+            // record the invoice id as the external_ref and mark the payout
+            // as paid only when the seller's NWC actually settles it. For
+            // now, store the bolt11 and let the seller pay it out-of-band
+            // by clicking "Mark paid" with the invoice as a note.
+            results.push({
+              affiliateId,
+              currency: bundle.currency,
+              method: "lightning",
+              success: false,
+              error: `Lightning payout requires manual settlement; invoice: ${invoice.paymentRequest}`,
+            });
+          } catch (err) {
+            results.push({
+              affiliateId,
+              currency: bundle.currency,
+              method: "lightning",
+              success: false,
+              error:
+                err instanceof Error
+                  ? err.message
+                  : "Lightning invoice fetch failed",
+            });
+          }
+        } else if (useStripe) {
+          try {
+            const transfer = await stripe.transfers.create(
+              {
+                amount: total,
+                currency: bundle.currency.toLowerCase(),
+                destination: affiliate.stripe_account_id!,
+                metadata: {
+                  affiliateId: String(affiliateId),
+                  scheduledPayout: "true",
+                  schedule,
+                },
+              },
+              {
+                idempotencyKey: `affiliate-payout-${affiliateId}-${Date.now()}`,
+              }
+            );
+            const { payoutId } = await createPayoutAndSettle({
+              affiliateId,
+              sellerPubkey: bundle.seller_pubkey,
+              method: "stripe",
+              amountSmallest: total,
+              currency: bundle.currency,
+              externalRef: transfer.id,
+              referralIds: bundle.referral_ids,
+            });
+            results.push({
+              affiliateId,
+              currency: bundle.currency,
+              method: "stripe",
+              success: true,
+              amountSmallest: total,
+              payoutId,
+            });
+          } catch (err) {
+            results.push({
+              affiliateId,
+              currency: bundle.currency,
+              method: "stripe",
+              success: false,
+              error:
+                err instanceof Error ? err.message : "Stripe transfer failed",
+            });
+          }
+        } else {
+          // No payout method connected — accrue silently for the seller to
+          // settle out-of-band. Leave referrals in 'payable' so they show up
+          // on the seller dashboard as "ready to pay".
+          results.push({
+            affiliateId,
+            currency: bundle.currency,
+            method: "manual",
+            success: true,
+            amountSmallest: total,
+          });
+        }
+      }
+    }
+
+    return res.status(200).json({ schedule, processed: results });
+  } catch (err) {
+    console.error("affiliates/process-payouts error:", err);
+    return res.status(500).json({ error: "Internal error" });
+  }
+}

--- a/pages/api/affiliates/record-click.ts
+++ b/pages/api/affiliates/record-click.ts
@@ -1,0 +1,70 @@
+/**
+ * Public click-tracking endpoint for affiliate links. Called by the front-end
+ * `<AffiliateRefTracker>` mounted in `_app.tsx` whenever it stores a fresh
+ * `?ref=CODE` cookie. Idempotent for the request lifecycle but not across
+ * page loads — the front-end gates the call so a single landing only fires
+ * once per session via sessionStorage.
+ *
+ * Intentionally records *no* IP, no user-agent. We only need clicks-vs-
+ * conversions for conversion-rate analytics; rich attribution belongs in a
+ * separate analytics product.
+ */
+import type { NextApiRequest, NextApiResponse } from "next";
+import { recordAffiliateClick } from "@/utils/db/affiliates";
+import { applyRateLimit } from "@/utils/rate-limit";
+
+const RATE_LIMIT = { limit: 120, windowMs: 60 * 1000 };
+
+function safeHost(referer: string | undefined): string | null {
+  if (!referer) return null;
+  try {
+    return new URL(referer).host.slice(0, 255) || null;
+  } catch {
+    return null;
+  }
+}
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  if (req.method !== "POST") {
+    return res.status(405).json({ error: "Method not allowed" });
+  }
+  if (!applyRateLimit(req, res, "affiliates-record-click", RATE_LIMIT)) return;
+
+  try {
+    const { sellerPubkey, code, landingPath } = req.body ?? {};
+    if (
+      !sellerPubkey ||
+      typeof sellerPubkey !== "string" ||
+      !/^[0-9a-f]{64}$/i.test(sellerPubkey) ||
+      !code ||
+      typeof code !== "string" ||
+      code.length === 0 ||
+      code.length > 64
+    ) {
+      // 200 to avoid the front-end retrying a bad request indefinitely; we
+      // already validated upstream in the tracker. The lack of an `ok: true`
+      // signals we silently dropped the row.
+      return res.status(200).json({ ok: false });
+    }
+    const path =
+      typeof landingPath === "string" && landingPath.length <= 512
+        ? landingPath
+        : null;
+    const refererHost = safeHost(req.headers.referer);
+
+    await recordAffiliateClick({
+      sellerPubkey: sellerPubkey.toLowerCase(),
+      code,
+      landingPath: path,
+      refererHost,
+    });
+    return res.status(200).json({ ok: true });
+  } catch (err) {
+    console.error("affiliates/record-click error:", err);
+    // Still 200: click-loss is preferable to retries hammering the table.
+    return res.status(200).json({ ok: false });
+  }
+}

--- a/pages/api/affiliates/record-referral.ts
+++ b/pages/api/affiliates/record-referral.ts
@@ -1,0 +1,100 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import {
+  computeBuyerDiscountSmallest,
+  computeRebateSmallest,
+  incrementAffiliateCodeUsage,
+  isAffiliateCodeValid,
+  lookupAffiliateCode,
+  recordReferral,
+} from "@/utils/db/affiliates";
+import { applyRateLimit } from "@/utils/rate-limit";
+
+const RATE_LIMIT = { limit: 120, windowMs: 60 * 1000 };
+
+/**
+ * Called by the cart/checkout flow after a successful order to attribute the
+ * sale to an affiliate code. We compute rebate + discount server-side so the
+ * client cannot inflate either.
+ *
+ * `realtimeTransferRef` is set when the payment rail already paid the
+ * affiliate inline (Stripe Connect transfer for an "every_sale" code). In
+ * that case we record the referral as `paid` straight away.
+ */
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  if (req.method !== "POST") {
+    return res.status(405).json({ error: "Method not allowed" });
+  }
+  if (!applyRateLimit(req, res, "affiliates-record-referral", RATE_LIMIT))
+    return;
+
+  try {
+    const {
+      sellerPubkey,
+      code,
+      orderId,
+      paymentRail,
+      grossSubtotalSmallest,
+      currency,
+      realtimeTransferRef,
+    } = req.body ?? {};
+
+    if (
+      !sellerPubkey ||
+      !code ||
+      !orderId ||
+      !paymentRail ||
+      grossSubtotalSmallest == null ||
+      !currency
+    ) {
+      return res.status(400).json({ error: "Missing required fields" });
+    }
+
+    const found = await lookupAffiliateCode(sellerPubkey, code);
+    if (!found || !(await isAffiliateCodeValid(found))) {
+      return res.status(400).json({ error: "Invalid affiliate code" });
+    }
+
+    const gross = Number(grossSubtotalSmallest);
+    const buyerDiscountSmallest = computeBuyerDiscountSmallest(
+      gross,
+      found.buyer_discount_type,
+      Number(found.buyer_discount_value)
+    );
+    const net = Math.max(gross - buyerDiscountSmallest, 0);
+    const rebateSmallest = computeRebateSmallest(
+      net,
+      found.rebate_type,
+      Number(found.rebate_value)
+    );
+
+    const initialStatus = realtimeTransferRef ? "paid" : "pending";
+
+    const referral = await recordReferral({
+      affiliateId: found.affiliate_id,
+      codeId: found.id,
+      sellerPubkey,
+      orderId: String(orderId),
+      paymentRail,
+      grossSubtotalSmallest: gross,
+      buyerDiscountSmallest,
+      rebateSmallest,
+      currency,
+      initialStatus,
+      realtimeTransferRef: realtimeTransferRef ?? null,
+    });
+    await incrementAffiliateCodeUsage(found.id);
+
+    return res.status(200).json({
+      success: true,
+      referralId: referral.id,
+      buyerDiscountSmallest,
+      rebateSmallest,
+    });
+  } catch (err) {
+    console.error("affiliates/record-referral error:", err);
+    return res.status(500).json({ error: "Internal error" });
+  }
+}

--- a/pages/api/affiliates/record-referral.ts
+++ b/pages/api/affiliates/record-referral.ts
@@ -2,8 +2,8 @@ import type { NextApiRequest, NextApiResponse } from "next";
 import {
   computeBuyerDiscountSmallest,
   computeRebateSmallest,
-  incrementAffiliateCodeUsage,
   isAffiliateCodeValid,
+  isSelfReferral,
   lookupAffiliateCode,
   recordReferral,
 } from "@/utils/db/affiliates";
@@ -16,9 +16,13 @@ const RATE_LIMIT = { limit: 120, windowMs: 60 * 1000 };
  * sale to an affiliate code. We compute rebate + discount server-side so the
  * client cannot inflate either.
  *
- * `realtimeTransferRef` is set when the payment rail already paid the
- * affiliate inline (Stripe Connect transfer for an "every_sale" code). In
- * that case we record the referral as `paid` straight away.
+ * Real-time payouts were removed; all referrals start as 'pending' and are
+ * promoted to 'payable' by the scheduled cron once they age past the hold
+ * window for their code's payout schedule.
+ *
+ * This endpoint is a best-effort backstop for buyer-driven flows (e.g.
+ * Cashu). The Stripe path also records referrals server-side from
+ * process-transfers / webhook so the attribution survives a closed tab.
  */
 export default async function handler(
   req: NextApiRequest,
@@ -31,22 +35,25 @@ export default async function handler(
     return;
 
   try {
+    // Accept both `grossSmallest` (legacy cart payload) and
+    // `grossSubtotalSmallest` (server payload) as aliases.
     const {
       sellerPubkey,
       code,
       orderId,
       paymentRail,
       grossSubtotalSmallest,
+      grossSmallest,
       currency,
-      realtimeTransferRef,
     } = req.body ?? {};
+    const gross = Number(grossSubtotalSmallest ?? grossSmallest);
 
     if (
       !sellerPubkey ||
       !code ||
       !orderId ||
       !paymentRail ||
-      grossSubtotalSmallest == null ||
+      !Number.isFinite(gross) ||
       !currency
     ) {
       return res.status(400).json({ error: "Missing required fields" });
@@ -57,7 +64,28 @@ export default async function handler(
       return res.status(400).json({ error: "Invalid affiliate code" });
     }
 
-    const gross = Number(grossSubtotalSmallest);
+    // Currency guard for fixed-amount codes: a $10 fixed discount priced in
+    // USD cannot be silently applied to a sats invoice. Percent codes are
+    // currency-agnostic so they still pass here.
+    if (
+      found.currency &&
+      String(currency).toLowerCase() !== found.currency.toLowerCase() &&
+      (found.buyer_discount_type === "fixed" || found.rebate_type === "fixed")
+    ) {
+      return res
+        .status(400)
+        .json({ error: "Affiliate code currency does not match order" });
+    }
+
+    // Block obvious self-referral abuse — a seller claiming their own
+    // affiliate code as the buyer to siphon the platform's rebate share.
+    if (
+      found.affiliate &&
+      isSelfReferral(sellerPubkey, found.affiliate.affiliate_pubkey)
+    ) {
+      return res.status(400).json({ error: "Self-referral is not allowed" });
+    }
+
     const buyerDiscountSmallest = computeBuyerDiscountSmallest(
       gross,
       found.buyer_discount_type,
@@ -70,22 +98,27 @@ export default async function handler(
       Number(found.rebate_value)
     );
 
-    const initialStatus = realtimeTransferRef ? "paid" : "pending";
-
-    const referral = await recordReferral({
-      affiliateId: found.affiliate_id,
-      codeId: found.id,
-      sellerPubkey,
-      orderId: String(orderId),
-      paymentRail,
-      grossSubtotalSmallest: gross,
-      buyerDiscountSmallest,
-      rebateSmallest,
-      currency,
-      initialStatus,
-      realtimeTransferRef: realtimeTransferRef ?? null,
-    });
-    await incrementAffiliateCodeUsage(found.id);
+    // recordReferral handles atomic max_uses enforcement + idempotency. If
+    // the code is full or inactive it throws; we surface that as 409.
+    let referral;
+    try {
+      referral = await recordReferral({
+        affiliateId: found.affiliate_id,
+        codeId: found.id,
+        sellerPubkey,
+        orderId: String(orderId),
+        paymentRail,
+        grossSubtotalSmallest: gross,
+        buyerDiscountSmallest,
+        rebateSmallest,
+        currency,
+        initialStatus: "pending",
+        realtimeTransferRef: null,
+      });
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : "record-referral failed";
+      return res.status(409).json({ error: msg });
+    }
 
     return res.status(200).json({
       success: true,

--- a/pages/api/affiliates/reverse-referral.ts
+++ b/pages/api/affiliates/reverse-referral.ts
@@ -1,0 +1,87 @@
+/**
+ * Seller-driven manual reversal of an affiliate referral. Lightning/Cashu
+ * orders that the seller refunds out-of-band have no Stripe webhook to fire
+ * `reverseReferralsForOrder` automatically, so the seller dashboard exposes
+ * a button that calls this endpoint with `(orderId, sellerPubkey)`.
+ *
+ * Behavior matches the Stripe webhook path: still-pending rebates are
+ * cancelled in full or scaled to the partial-refund ratio; already-paid
+ * rebates have the proportional clawback recorded for out-of-band
+ * reconciliation.
+ */
+import type { NextApiRequest, NextApiResponse } from "next";
+import { reverseReferralsForOrder } from "@/utils/db/affiliates";
+import {
+  buildAffiliateReverseReferralProof,
+  extractSignedEventFromRequest,
+  verifySignedHttpRequestProof,
+} from "@/utils/nostr/request-auth";
+import { applyRateLimit } from "@/utils/rate-limit";
+
+const RATE_LIMIT = { limit: 30, windowMs: 60 * 1000 };
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  if (req.method !== "POST") {
+    return res.status(405).json({ error: "Method not allowed" });
+  }
+  if (!applyRateLimit(req, res, "affiliates-reverse-referral", RATE_LIMIT))
+    return;
+
+  try {
+    const {
+      pubkey,
+      orderId,
+      sellerPubkey,
+      originalGrossSmallest,
+      refundedSmallest,
+      note,
+    } = req.body ?? {};
+
+    if (
+      !pubkey ||
+      !orderId ||
+      typeof orderId !== "string" ||
+      !sellerPubkey ||
+      typeof sellerPubkey !== "string"
+    ) {
+      return res.status(400).json({ error: "Missing required fields" });
+    }
+    if (pubkey !== sellerPubkey) {
+      // The signing pubkey must match the seller whose referrals are being
+      // reversed; otherwise a seller could reverse a competitor's referrals.
+      return res.status(403).json({ error: "Pubkey/seller mismatch" });
+    }
+
+    const v = verifySignedHttpRequestProof(
+      extractSignedEventFromRequest(req),
+      buildAffiliateReverseReferralProof({
+        pubkey,
+        orderId,
+        sellerPubkey,
+      })
+    );
+    if (!v.ok) return res.status(v.status).json({ error: v.error });
+
+    const result = await reverseReferralsForOrder({
+      orderId,
+      sellerPubkey,
+      originalGrossSmallest:
+        typeof originalGrossSmallest === "number"
+          ? originalGrossSmallest
+          : undefined,
+      refundedSmallest:
+        typeof refundedSmallest === "number" ? refundedSmallest : undefined,
+      refundEventRef:
+        typeof note === "string" && note.length <= 256
+          ? `manual:${note}`
+          : "manual",
+    });
+    return res.status(200).json({ success: true, ...result });
+  } catch (err) {
+    console.error("affiliates/reverse-referral error:", err);
+    return res.status(500).json({ error: "Internal error" });
+  }
+}

--- a/pages/api/affiliates/self-stats.ts
+++ b/pages/api/affiliates/self-stats.ts
@@ -1,0 +1,47 @@
+/**
+ * Affiliate self-service stats endpoint. Authenticated by the same invite
+ * token the affiliate uses for `/affiliate/[token]`. Returns balances and
+ * recent payouts for the holder of the link, with sensitive details masked
+ * the same way `/api/affiliates/claim` does.
+ */
+import type { NextApiRequest, NextApiResponse } from "next";
+import {
+  getAffiliateBalancesByToken,
+  listRecentPayoutsForAffiliate,
+} from "@/utils/db/affiliates";
+import { applyRateLimit } from "@/utils/rate-limit";
+
+const RATE_LIMIT = { limit: 60, windowMs: 60 * 1000 };
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  if (req.method !== "GET") {
+    return res.status(405).json({ error: "Method not allowed" });
+  }
+  if (!applyRateLimit(req, res, "affiliates-self-stats", RATE_LIMIT)) return;
+
+  const { token } = req.query;
+  if (!token || typeof token !== "string") {
+    return res.status(400).json({ error: "token required" });
+  }
+
+  try {
+    const result = await getAffiliateBalancesByToken(token);
+    if (!result) return res.status(404).json({ error: "Invite not found" });
+    const payouts = await listRecentPayoutsForAffiliate(result.affiliate.id);
+    return res.status(200).json({
+      affiliateId: result.affiliate.id,
+      name: result.affiliate.name,
+      payoutsEnabled: result.affiliate.payouts_enabled,
+      lastFailureReason: result.affiliate.last_payout_failure_reason,
+      lastFailureAt: result.affiliate.last_payout_failure_at,
+      balances: result.balances,
+      payouts,
+    });
+  } catch (err) {
+    console.error("affiliates/self-stats error:", err);
+    return res.status(500).json({ error: "Internal error" });
+  }
+}

--- a/pages/api/affiliates/stripe-onboarding.ts
+++ b/pages/api/affiliates/stripe-onboarding.ts
@@ -1,0 +1,147 @@
+/**
+ * Stripe Connect onboarding for an affiliate, gated by their invite token.
+ *
+ * Two POST actions:
+ *   - action="create-account": creates a Stripe Express account for the
+ *     affiliate (using their email if known) and stores the account id on
+ *     the affiliate row.
+ *   - action="create-link": returns an Account Link URL the affiliate can
+ *     follow to finish onboarding. Safe to re-call repeatedly.
+ *
+ * Auth model: knowledge of the invite token. Once the invite has been
+ * claimed by a pubkey, this endpoint refuses to mutate the stripe_account_id
+ * unless the body includes the same affiliate_pubkey (matches the policy
+ * already enforced by the `claim` endpoint).
+ */
+import type { NextApiRequest, NextApiResponse } from "next";
+import Stripe from "stripe";
+import {
+  getAffiliateByInviteToken,
+  updateAffiliatePayoutMethod,
+} from "@/utils/db/affiliates";
+import { applyRateLimit } from "@/utils/rate-limit";
+
+const RATE_LIMIT = { limit: 12, windowMs: 60 * 1000 };
+
+const stripe = new Stripe(process.env.STRIPE_SECRET_KEY || "", {
+  apiVersion: "2025-09-30.clover",
+});
+
+function isAllowedAbsoluteRedirect(url: string): boolean {
+  try {
+    const parsed = new URL(url);
+    return parsed.protocol === "https:" || parsed.protocol === "milkmarket:";
+  } catch {
+    return false;
+  }
+}
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  if (req.method !== "POST") {
+    return res.status(405).json({ error: "Method not allowed" });
+  }
+  if (!applyRateLimit(req, res, "affiliates-stripe-onboarding", RATE_LIMIT))
+    return;
+  if (!process.env.STRIPE_SECRET_KEY) {
+    return res
+      .status(500)
+      .json({ error: "Stripe is not configured on this server" });
+  }
+
+  try {
+    const {
+      token,
+      action,
+      affiliatePubkey,
+      returnUrl: rawReturnUrl,
+      refreshUrl: rawRefreshUrl,
+    } = req.body ?? {};
+    if (!token || typeof token !== "string") {
+      return res.status(400).json({ error: "token required" });
+    }
+    if (action !== "create-account" && action !== "create-link") {
+      return res.status(400).json({ error: "Invalid action" });
+    }
+
+    const existing = await getAffiliateByInviteToken(token);
+    if (!existing) return res.status(404).json({ error: "Invite not found" });
+
+    // After-claim guard: must come from the claiming pubkey.
+    if (existing.affiliate_pubkey) {
+      if (!affiliatePubkey || existing.affiliate_pubkey !== affiliatePubkey) {
+        return res
+          .status(403)
+          .json({ error: "Invite already claimed by another pubkey" });
+      }
+    }
+
+    const baseUrl =
+      process.env.NEXT_PUBLIC_BASE_URL ||
+      (process.env.REPLIT_DEV_DOMAIN
+        ? `https://${process.env.REPLIT_DEV_DOMAIN}`
+        : "http://localhost:3000");
+    const safeReturnUrl =
+      typeof rawReturnUrl === "string" &&
+      rawReturnUrl &&
+      isAllowedAbsoluteRedirect(rawReturnUrl)
+        ? rawReturnUrl
+        : `${baseUrl}/affiliate/${encodeURIComponent(token)}?stripe=return`;
+    const safeRefreshUrl =
+      typeof rawRefreshUrl === "string" &&
+      rawRefreshUrl &&
+      isAllowedAbsoluteRedirect(rawRefreshUrl)
+        ? rawRefreshUrl
+        : `${baseUrl}/affiliate/${encodeURIComponent(token)}?stripe=refresh`;
+
+    let accountId = existing.stripe_account_id;
+
+    if (action === "create-account") {
+      if (accountId) {
+        // Idempotent: return the existing account id so a double-click
+        // doesn't create a second Connect account.
+        return res.status(200).json({ accountId, alreadyExists: true });
+      }
+      const account = await stripe.accounts.create({
+        type: "express",
+        email: existing.email ?? undefined,
+        capabilities: {
+          transfers: { requested: true },
+        },
+        metadata: {
+          affiliateId: String(existing.id),
+          inviteToken: token,
+        },
+      });
+      accountId = account.id;
+      await updateAffiliatePayoutMethod(token, {
+        affiliatePubkey: existing.affiliate_pubkey,
+        lightningAddress: existing.lightning_address,
+        stripeAccountId: accountId,
+      });
+      return res.status(200).json({ accountId, alreadyExists: false });
+    }
+
+    // action === "create-link"
+    if (!accountId) {
+      return res
+        .status(400)
+        .json({ error: "No Stripe account; create one first" });
+    }
+    const link = await stripe.accountLinks.create({
+      account: accountId,
+      refresh_url: safeRefreshUrl,
+      return_url: safeReturnUrl,
+      type: "account_onboarding",
+    });
+    return res.status(200).json({ url: link.url, accountId });
+  } catch (err) {
+    console.error("affiliates/stripe-onboarding error:", err);
+    return res.status(500).json({
+      error: "Internal error",
+      details: err instanceof Error ? err.message : "Unknown",
+    });
+  }
+}

--- a/pages/api/affiliates/unsubscribe.ts
+++ b/pages/api/affiliates/unsubscribe.ts
@@ -1,0 +1,84 @@
+/**
+ * One-click unsubscribe for affiliate transactional emails. The link is
+ * signed with `AFFILIATE_UNSUBSCRIBE_SECRET` so it carries no DB lookup of
+ * the invite token (we never want to leak the invite token via an email
+ * that the affiliate's mail provider may store indefinitely).
+ *
+ * GET shows a tiny HTML acknowledgement; POST is wired to support
+ * `List-Unsubscribe-Post` + `One-Click` per RFC 8058 so Gmail/Yahoo treat
+ * the link as a real unsubscribe.
+ */
+import type { NextApiRequest, NextApiResponse } from "next";
+import { getAffiliateById } from "@/utils/db/affiliates";
+import {
+  assertAffiliateUnsubscribeSecretConfigured,
+  verifyAffiliateUnsubscribeToken,
+} from "@/utils/email/unsubscribe-tokens";
+import { applyRateLimit } from "@/utils/rate-limit";
+
+// Fail the route module load in production if the secret is missing — so
+// the deploy never silently serves an unsubscribe URL that 500s on every hit.
+assertAffiliateUnsubscribeSecretConfigured();
+
+const RATE_LIMIT = { limit: 60, windowMs: 60 * 1000 };
+
+async function disableNotifications(affiliateId: number): Promise<boolean> {
+  const aff = await getAffiliateById(affiliateId);
+  if (!aff) return false;
+  const mod = await import("@/utils/db/affiliates");
+  const updated = await mod.setAffiliateEmailNotifications(
+    aff.invite_token,
+    false
+  );
+  return !!updated;
+}
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  if (req.method !== "GET" && req.method !== "POST") {
+    return res.status(405).json({ error: "Method not allowed" });
+  }
+  if (!applyRateLimit(req, res, "affiliates-unsubscribe", RATE_LIMIT)) return;
+
+  const token =
+    (req.query.token as string | undefined) ??
+    (req.body && (req.body.token as string | undefined));
+  if (!token) {
+    return res.status(400).send("Missing token");
+  }
+
+  let parsed: { affiliateId: number } | null = null;
+  try {
+    parsed = verifyAffiliateUnsubscribeToken(token);
+  } catch (err) {
+    console.error("unsubscribe verify error:", err);
+    return res.status(500).send("Server error");
+  }
+  if (!parsed) return res.status(400).send("Invalid or expired link");
+
+  try {
+    const ok = await disableNotifications(parsed.affiliateId);
+    if (req.method === "POST") {
+      // RFC 8058 one-click flow: just acknowledge with 200.
+      return res.status(200).end();
+    }
+    res.setHeader("Content-Type", "text/html; charset=utf-8");
+    if (!ok) {
+      return res
+        .status(200)
+        .send(
+          `<html><body style="font-family:sans-serif;max-width:480px;margin:48px auto;padding:0 16px;"><h2>Already unsubscribed</h2><p>We couldn't find an active record for that link. You won't receive further affiliate notifications from this account.</p></body></html>`
+        );
+    }
+    return res
+      .status(200)
+      .send(
+        `<html><body style="font-family:sans-serif;max-width:480px;margin:48px auto;padding:0 16px;"><h2>You're unsubscribed</h2><p>Affiliate payout notifications have been disabled. You can re-enable them from your affiliate self-service page at any time.</p></body></html>`
+      );
+  } catch (err) {
+    console.error("affiliates/unsubscribe error:", err);
+    return res.status(500).send("Server error");
+  }
+}

--- a/pages/api/affiliates/validate.ts
+++ b/pages/api/affiliates/validate.ts
@@ -7,7 +7,10 @@ import {
 } from "@/utils/db/affiliates";
 import { applyRateLimit } from "@/utils/rate-limit";
 
-const RATE_LIMIT = { limit: 240, windowMs: 60 * 1000 };
+// Lower than the seller-authenticated endpoints because this one is
+// unauthenticated and would otherwise be a convenient enumeration oracle for
+// guessing valid codes. 60/min is still ample for the cart UX.
+const RATE_LIMIT = { limit: 60, windowMs: 60 * 1000 };
 
 /**
  * Public buyer-side validation. Given a seller pubkey + code (and optionally
@@ -24,15 +27,27 @@ export default async function handler(
   if (!applyRateLimit(req, res, "affiliates-validate", RATE_LIMIT)) return;
 
   try {
-    const { sellerPubkey, code, grossSmallest } = req.query;
+    const { sellerPubkey, code, grossSmallest, currency } = req.query;
     if (!sellerPubkey || !code) {
-      return res
-        .status(400)
-        .json({ valid: false, error: "sellerPubkey and code required" });
+      // Uniform shape with the not-found case to avoid leaking which inputs
+      // the endpoint accepts vs. rejects.
+      return res.status(200).json({ valid: false });
     }
     const found = await lookupAffiliateCode(String(sellerPubkey), String(code));
     if (!found) return res.status(200).json({ valid: false });
     if (!(await isAffiliateCodeValid(found))) {
+      return res.status(200).json({ valid: false });
+    }
+    // Currency guard: a fixed-amount code stored in one currency cannot be
+    // safely applied to an order in a different currency (e.g. a $5 code
+    // applied to a sats invoice would shave off 5 sats). For percent codes
+    // this is currency-agnostic so we still allow it.
+    if (
+      typeof currency === "string" &&
+      found.currency &&
+      found.currency.toLowerCase() !== currency.toLowerCase() &&
+      (found.buyer_discount_type === "fixed" || found.rebate_type === "fixed")
+    ) {
       return res.status(200).json({ valid: false });
     }
 

--- a/pages/api/affiliates/validate.ts
+++ b/pages/api/affiliates/validate.ts
@@ -1,0 +1,69 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import {
+  computeBuyerDiscountSmallest,
+  computeRebateSmallest,
+  isAffiliateCodeValid,
+  lookupAffiliateCode,
+} from "@/utils/db/affiliates";
+import { applyRateLimit } from "@/utils/rate-limit";
+
+const RATE_LIMIT = { limit: 240, windowMs: 60 * 1000 };
+
+/**
+ * Public buyer-side validation. Given a seller pubkey + code (and optionally
+ * a gross subtotal in smallest units), returns whether the code is valid and
+ * the buyer-discount preview.
+ */
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  if (req.method !== "GET") {
+    return res.status(405).json({ error: "Method not allowed" });
+  }
+  if (!applyRateLimit(req, res, "affiliates-validate", RATE_LIMIT)) return;
+
+  try {
+    const { sellerPubkey, code, grossSmallest } = req.query;
+    if (!sellerPubkey || !code) {
+      return res
+        .status(400)
+        .json({ valid: false, error: "sellerPubkey and code required" });
+    }
+    const found = await lookupAffiliateCode(String(sellerPubkey), String(code));
+    if (!found) return res.status(200).json({ valid: false });
+    if (!(await isAffiliateCodeValid(found))) {
+      return res.status(200).json({ valid: false });
+    }
+
+    const gross = grossSmallest ? Number(grossSmallest) : 0;
+    const buyerDiscountSmallest = computeBuyerDiscountSmallest(
+      gross,
+      found.buyer_discount_type,
+      Number(found.buyer_discount_value)
+    );
+    const net = Math.max(gross - buyerDiscountSmallest, 0);
+    const rebateSmallest = computeRebateSmallest(
+      net,
+      found.rebate_type,
+      Number(found.rebate_value)
+    );
+
+    return res.status(200).json({
+      valid: true,
+      codeId: found.id,
+      affiliateId: found.affiliate_id,
+      affiliateName: found.affiliate.name,
+      buyerDiscountType: found.buyer_discount_type,
+      buyerDiscountValue: Number(found.buyer_discount_value),
+      buyerDiscountSmallest,
+      rebateType: found.rebate_type,
+      rebateValue: Number(found.rebate_value),
+      rebateSmallest,
+      payoutSchedule: found.payout_schedule,
+    });
+  } catch (err) {
+    console.error("affiliates/validate error:", err);
+    return res.status(500).json({ valid: false, error: "Internal error" });
+  }
+}

--- a/pages/api/affiliates/ytd-payouts.ts
+++ b/pages/api/affiliates/ytd-payouts.ts
@@ -1,0 +1,65 @@
+/**
+ * Year-to-date payout totals per affiliate, scoped to a seller. Useful for
+ * 1099-MISC reporting where US sellers must issue a form for any non-employee
+ * paid >= $600 in a calendar year. The endpoint just emits the totals; the
+ * 1099 itself is the seller's responsibility (often via Stripe Tax 1099).
+ */
+import type { NextApiRequest, NextApiResponse } from "next";
+import { getYearToDatePayouts } from "@/utils/db/affiliates";
+import {
+  buildAffiliatesListProof,
+  extractSignedEventFromRequest,
+  verifySignedHttpRequestProof,
+} from "@/utils/nostr/request-auth";
+import { applyRateLimit } from "@/utils/rate-limit";
+
+const RATE_LIMIT = { limit: 30, windowMs: 60 * 1000 };
+// IRS 1099-NEC threshold for non-employee compensation in a calendar year.
+const US_1099_THRESHOLD_CENTS = 60000;
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  if (req.method !== "GET") {
+    return res.status(405).json({ error: "Method not allowed" });
+  }
+  if (!applyRateLimit(req, res, "affiliates-ytd-payouts", RATE_LIMIT)) return;
+
+  const { pubkey, year } = req.query;
+  if (!pubkey || typeof pubkey !== "string") {
+    return res.status(400).json({ error: "pubkey required" });
+  }
+  const yr = year ? Number(year) : new Date().getUTCFullYear();
+  if (!Number.isInteger(yr) || yr < 2024 || yr > 2100) {
+    return res.status(400).json({ error: "Invalid year" });
+  }
+
+  // Reuse the affiliates-list proof: scoped to the same seller, same kind of
+  // read-only operation so we don't need a new proof type.
+  const v = verifySignedHttpRequestProof(
+    extractSignedEventFromRequest(req),
+    buildAffiliatesListProof(pubkey)
+  );
+  if (!v.ok) return res.status(v.status).json({ error: v.error });
+
+  try {
+    const totals = await getYearToDatePayouts(pubkey, yr);
+    const flagged = totals
+      .filter(
+        (t) =>
+          t.currency.toLowerCase() !== "sats" &&
+          Number(t.total_smallest) >= US_1099_THRESHOLD_CENTS
+      )
+      .map((t) => t.affiliate_id);
+    return res.status(200).json({
+      year: yr,
+      totals,
+      flaggedFor1099: flagged,
+      thresholdCents: US_1099_THRESHOLD_CENTS,
+    });
+  } catch (err) {
+    console.error("affiliates/ytd-payouts error:", err);
+    return res.status(500).json({ error: "Internal error" });
+  }
+}

--- a/pages/api/stripe/create-payment-intent.ts
+++ b/pages/api/stripe/create-payment-intent.ts
@@ -19,6 +19,16 @@ interface SellerSplit {
   // Legacy raw-amount field, kept for back-compat with any older callers.
   amount?: number;
   currency: string;
+  // Optional affiliate attribution — when present, the seller's share will be
+  // reduced by `affiliateRebateSmallest` and that amount will be transferred
+  // to `affiliateAccountId` (Stripe Connect) by process-transfers. If no
+  // account is connected we still record the rebate in metadata so it can
+  // accrue to the affiliate's balance.
+  affiliateRebateSmallest?: number;
+  affiliateAccountId?: string | null;
+  affiliateId?: number;
+  affiliateCodeId?: number;
+  affiliateCode?: string;
 }
 import { applyRateLimit } from "@/utils/rate-limit";
 import {
@@ -79,6 +89,11 @@ export default async function handler(
       accountId: string;
       donationPercent: number;
       donationCutSmallest: number;
+      affiliateRebateSmallest: number;
+      affiliateAccountId: string | null;
+      affiliateId: number | null;
+      affiliateCodeId: number | null;
+      affiliateCode: string | null;
     }[] = [];
 
     if (isMultiMerchant) {
@@ -142,6 +157,20 @@ export default async function handler(
           accountId,
           donationPercent,
           donationCutSmallest,
+          affiliateRebateSmallest:
+            typeof split.affiliateRebateSmallest === "number"
+              ? Math.max(
+                  0,
+                  Math.min(
+                    split.affiliateRebateSmallest,
+                    Math.max(splitAmountSmallest - donationCutSmallest - 1, 0)
+                  )
+                )
+              : 0,
+          affiliateAccountId: split.affiliateAccountId ?? null,
+          affiliateId: split.affiliateId ?? null,
+          affiliateCodeId: split.affiliateCodeId ?? null,
+          affiliateCode: split.affiliateCode ?? null,
         });
       }
 
@@ -180,6 +209,11 @@ export default async function handler(
               accountId: s.accountId,
               donationPercent: s.donationPercent,
               donationCutSmallest: s.donationCutSmallest,
+              affiliateRebateSmallest: s.affiliateRebateSmallest,
+              affiliateAccountId: s.affiliateAccountId,
+              affiliateId: s.affiliateId,
+              affiliateCodeId: s.affiliateCodeId,
+              affiliateCode: s.affiliateCode,
             }))
           ),
         },
@@ -239,6 +273,11 @@ export default async function handler(
           accountId: s.accountId,
           donationPercent: s.donationPercent,
           donationCutSmallest: s.donationCutSmallest,
+          affiliateRebateSmallest: s.affiliateRebateSmallest,
+          affiliateAccountId: s.affiliateAccountId,
+          affiliateId: s.affiliateId,
+          affiliateCodeId: s.affiliateCodeId,
+          affiliateCode: s.affiliateCode,
         })),
       });
     }

--- a/pages/api/stripe/process-transfers.ts
+++ b/pages/api/stripe/process-transfers.ts
@@ -12,6 +12,11 @@ interface SellerSplit {
   accountId?: string;
   donationPercent?: number;
   donationCutSmallest?: number;
+  affiliateRebateSmallest?: number;
+  affiliateAccountId?: string | null;
+  affiliateId?: number | null;
+  affiliateCodeId?: number | null;
+  affiliateCode?: string | null;
 }
 import { applyRateLimit } from "@/utils/rate-limit";
 import { withStripeRetry } from "@/utils/stripe/retry-service";
@@ -66,6 +71,10 @@ export default async function handler(
       skipped?: boolean;
       donationCutSmallest?: number;
       transferredAmount?: number;
+      affiliateTransferId?: string;
+      affiliateRebateSmallest?: number;
+      affiliateAccrued?: boolean;
+      affiliateError?: string;
     }[] = [];
 
     for (const split of sellerSplits) {
@@ -128,7 +137,18 @@ export default async function handler(
         donationCut = resolved.cutSmallest;
       }
 
-      const transferAmount = Math.max(split.amountCents - donationCut, 0);
+      // Affiliate rebate: cap so the seller still keeps at least 1 unit after
+      // donation + rebate. The create-payment-intent endpoint already capped
+      // this; we re-cap defensively in case process-transfers is called with
+      // a stale or hand-rolled payload.
+      const requestedRebate = Math.max(split.affiliateRebateSmallest ?? 0, 0);
+      const maxAllowedRebate = Math.max(split.amountCents - donationCut - 1, 0);
+      const affiliateRebate = Math.min(requestedRebate, maxAllowedRebate);
+
+      const transferAmount = Math.max(
+        split.amountCents - donationCut - affiliateRebate,
+        0
+      );
       if (transferAmount <= 0) {
         results.push({
           sellerPubkey: split.sellerPubkey,
@@ -162,12 +182,53 @@ export default async function handler(
           )
         );
 
-        results.push({
+        const result: (typeof results)[number] = {
           sellerPubkey: split.sellerPubkey,
           transferId: transfer.id,
           donationCutSmallest: donationCut,
           transferredAmount: transferAmount,
-        });
+          affiliateRebateSmallest: affiliateRebate,
+        };
+
+        // Real-time affiliate transfer when a Stripe Connect destination is
+        // configured. If not, we leave it accruing — the cart's
+        // record-referral call will store the rebate against the affiliate
+        // balance for later settlement.
+        if (affiliateRebate > 0 && split.affiliateAccountId) {
+          try {
+            const affiliateTransfer = await withStripeRetry(() =>
+              stripe.transfers.create(
+                {
+                  amount: affiliateRebate,
+                  currency: transferCurrency,
+                  destination: split.affiliateAccountId!,
+                  transfer_group: transferGroup,
+                  metadata: {
+                    paymentIntentId,
+                    sellerPubkey: split.sellerPubkey,
+                    affiliateId: String(split.affiliateId ?? ""),
+                    affiliateCodeId: String(split.affiliateCodeId ?? ""),
+                    affiliateCode: split.affiliateCode ?? "",
+                    rebateSmallest: affiliateRebate.toString(),
+                  },
+                },
+                {
+                  idempotencyKey: `aff-${paymentIntentId}-${split.sellerPubkey}-${
+                    split.affiliateCodeId ?? "x"
+                  }`,
+                }
+              )
+            );
+            result.affiliateTransferId = affiliateTransfer.id;
+          } catch (e) {
+            result.affiliateError =
+              e instanceof Error ? e.message : "Affiliate transfer failed";
+          }
+        } else if (affiliateRebate > 0) {
+          result.affiliateAccrued = true;
+        }
+
+        results.push(result);
       } catch (transferError) {
         console.error(
           `Transfer failed for seller ${split.sellerPubkey}:`,

--- a/pages/api/stripe/process-transfers.ts
+++ b/pages/api/stripe/process-transfers.ts
@@ -24,6 +24,7 @@ import {
   resolveDonationCut,
   computeDonationCutSmallest,
 } from "@/utils/stripe/donation";
+import { recordReferral } from "@/utils/db/affiliates";
 
 // Rate limit: per-IP cap to bound abuse of payment endpoints.
 const RATE_LIMIT = { limit: 30, windowMs: 60000 };
@@ -63,6 +64,11 @@ export default async function handler(
     }
 
     const transferCurrency = paymentIntent.currency;
+    // Order id used for affiliate idempotency. Fall back to the PI id so we
+    // still get a stable unique key even when no orderId metadata was set.
+    const orderId =
+      (paymentIntent.metadata && paymentIntent.metadata.orderId) ||
+      paymentIntentId;
 
     const results: {
       sellerPubkey: string;
@@ -190,42 +196,34 @@ export default async function handler(
           affiliateRebateSmallest: affiliateRebate,
         };
 
-        // Real-time affiliate transfer when a Stripe Connect destination is
-        // configured. If not, we leave it accruing — the cart's
-        // record-referral call will store the rebate against the affiliate
-        // balance for later settlement.
-        if (affiliateRebate > 0 && split.affiliateAccountId) {
+        // Real-time affiliate transfers were removed. Always accrue the
+        // rebate server-side via recordReferral so the scheduler can settle
+        // it on the configured cadence — this keeps refund clawbacks
+        // deterministic. We do this on the server (not the client) so the
+        // referral is recorded even if the buyer closes the tab.
+        if (affiliateRebate > 0 && split.affiliateId && split.affiliateCodeId) {
           try {
-            const affiliateTransfer = await withStripeRetry(() =>
-              stripe.transfers.create(
-                {
-                  amount: affiliateRebate,
-                  currency: transferCurrency,
-                  destination: split.affiliateAccountId!,
-                  transfer_group: transferGroup,
-                  metadata: {
-                    paymentIntentId,
-                    sellerPubkey: split.sellerPubkey,
-                    affiliateId: String(split.affiliateId ?? ""),
-                    affiliateCodeId: String(split.affiliateCodeId ?? ""),
-                    affiliateCode: split.affiliateCode ?? "",
-                    rebateSmallest: affiliateRebate.toString(),
-                  },
-                },
-                {
-                  idempotencyKey: `aff-${paymentIntentId}-${split.sellerPubkey}-${
-                    split.affiliateCodeId ?? "x"
-                  }`,
-                }
-              )
-            );
-            result.affiliateTransferId = affiliateTransfer.id;
+            await recordReferral({
+              affiliateId: split.affiliateId,
+              codeId: split.affiliateCodeId,
+              sellerPubkey: split.sellerPubkey,
+              orderId,
+              paymentRail: "stripe",
+              grossSubtotalSmallest: split.amountCents,
+              buyerDiscountSmallest: 0,
+              rebateSmallest: affiliateRebate,
+              currency: transferCurrency,
+              initialStatus: "pending",
+              realtimeTransferRef: null,
+            });
+            result.affiliateAccrued = true;
+            result.affiliateRebateSmallest = affiliateRebate;
           } catch (e) {
             result.affiliateError =
-              e instanceof Error ? e.message : "Affiliate transfer failed";
+              e instanceof Error
+                ? e.message
+                : "Affiliate referral record failed";
           }
-        } else if (affiliateRebate > 0) {
-          result.affiliateAccrued = true;
         }
 
         results.push(result);

--- a/pages/api/stripe/webhook.ts
+++ b/pages/api/stripe/webhook.ts
@@ -23,6 +23,7 @@ export const config = {
 import { applyRateLimit } from "@/utils/rate-limit";
 import { claimStripeEvent } from "@/utils/stripe/processed-events";
 import { markPendingPaymentByIntent } from "@/utils/stripe/pending-payments";
+import { reverseReferralsForOrder } from "@/utils/db/affiliates";
 
 async function getRawBody(req: NextApiRequest): Promise<Buffer> {
   return new Promise((resolve, reject) => {
@@ -131,6 +132,45 @@ export default async function handler(
         );
         break;
       }
+      case "charge.refunded": {
+        // Refund reversal for affiliate referrals: when a buyer is refunded
+        // we cancel any still-pending referral and mark already-paid ones as
+        // 'refunded' so the seller can reconcile out-of-band with the
+        // affiliate. We key off paymentIntent.metadata.{orderId,sellerPubkey}
+        // because that's what create-payment-intent + cart write through.
+        const charge = event.data.object as Stripe.Charge;
+        try {
+          const piId =
+            typeof charge.payment_intent === "string"
+              ? charge.payment_intent
+              : charge.payment_intent?.id;
+          if (piId) {
+            const pi = await stripe.paymentIntents.retrieve(piId);
+            const orderId = (pi.metadata && pi.metadata.orderId) || piId;
+            const sellerPubkey = pi.metadata?.sellerPubkey;
+            if (sellerPubkey) {
+              const sellers = sellerPubkey.includes(",")
+                ? sellerPubkey.split(",")
+                : [sellerPubkey];
+              for (const sp of sellers) {
+                await reverseReferralsForOrder({
+                  orderId,
+                  sellerPubkey: sp.trim(),
+                  // Pass both amounts so the helper can scale the rebate
+                  // proportionally on partial refunds instead of clawing
+                  // the whole thing back.
+                  originalGrossSmallest: charge.amount ?? 0,
+                  refundedSmallest: charge.amount_refunded ?? 0,
+                  refundEventRef: event.id,
+                });
+              }
+            }
+          }
+        } catch (e) {
+          console.warn("affiliate refund reversal failed:", e);
+        }
+        break;
+      }
       case "application_fee.refunded": {
         const fee = event.data.object as Stripe.ApplicationFee;
         console.log(
@@ -139,6 +179,35 @@ export default async function handler(
               typeof fee.account === "string" ? fee.account : fee.account?.id
             }`
         );
+        break;
+      }
+      case "account.updated": {
+        // Mirror Stripe Connect onboarding state into our `affiliates` row so
+        // process-payouts can short-circuit on accounts that aren't yet able
+        // to receive transfers (charges_enabled / payouts_enabled). We match
+        // on `stripe_account_id`; non-affiliate Connect accounts (e.g.
+        // marketplace seller accounts handled elsewhere) simply won't match
+        // and the no-op is fine.
+        const account = event.data.object as Stripe.Account;
+        try {
+          const { syncAffiliateStripeAccountState } =
+            await import("@/utils/db/affiliates");
+          const matched = await syncAffiliateStripeAccountState({
+            stripeAccountId: account.id,
+            chargesEnabled: !!account.charges_enabled,
+            payoutsEnabled: !!account.payouts_enabled,
+            detailsSubmitted: !!account.details_submitted,
+          });
+          if (matched) {
+            console.log(
+              `AFFILIATE_STRIPE_ACCOUNT_UPDATED affiliate=${matched} acct=${account.id} ` +
+                `charges=${account.charges_enabled} payouts=${account.payouts_enabled} ` +
+                `details=${account.details_submitted}`
+            );
+          }
+        } catch (err) {
+          console.error("account.updated affiliate sync failed:", err);
+        }
         break;
       }
       default:

--- a/pages/api/stripe/webhook.ts
+++ b/pages/api/stripe/webhook.ts
@@ -181,6 +181,33 @@ export default async function handler(
         );
         break;
       }
+      case "account.application.deauthorized": {
+        // The connected account revoked our OAuth grant. We can no longer
+        // initiate transfers, so flip every cached stripe_* flag off; the
+        // process-payouts loop already short-circuits on
+        // stripe_payouts_enabled=false. The connected-account id arrives on
+        // the top-level `event.account` field for Connect events (not on
+        // `event.data.object`, which is the Application).
+        const acctId = (event as Stripe.Event & { account?: string }).account;
+        if (acctId) {
+          try {
+            const { markAffiliateStripeDeauthorized } =
+              await import("@/utils/db/affiliates");
+            const matched = await markAffiliateStripeDeauthorized(acctId);
+            if (matched) {
+              console.log(
+                `AFFILIATE_STRIPE_DEAUTHORIZED affiliate=${matched} acct=${acctId}`
+              );
+            }
+          } catch (err) {
+            console.error(
+              "account.application.deauthorized affiliate sync failed:",
+              err
+            );
+          }
+        }
+        break;
+      }
       case "account.updated": {
         // Mirror Stripe Connect onboarding state into our `affiliates` row so
         // process-payouts can short-circuit on accounts that aren't yet able

--- a/pages/cart/index.tsx
+++ b/pages/cart/index.tsx
@@ -163,6 +163,17 @@ export default function Component() {
   }>({});
   const [isValidatingDiscounts, setIsValidatingDiscounts] = useState(false);
 
+  type AffiliateMeta = {
+    code: string;
+    codeId: number;
+    affiliateId: number;
+    rebateType: "percent" | "fixed";
+    rebateValue: number;
+  };
+  const [affiliateMetaBySeller, setAffiliateMetaBySeller] = useState<{
+    [pubkey: string]: AffiliateMeta;
+  }>({});
+
   const [sellerStripeStatus, setSellerStripeStatus] = useState<
     Record<string, boolean>
   >({});
@@ -602,6 +613,60 @@ export default function Component() {
   }, [products, quantities, appliedDiscounts]);
 
   useEffect(() => {
+    if (typeof document === "undefined") return;
+    if (uniqueSellerPubkeys.length === 0) return;
+    const m = document.cookie.match(/(?:^|; )mm_aff_ref=([^;]*)/);
+    if (!m) return;
+    const code = decodeURIComponent(m[1]!);
+    if (!code) return;
+    let cancelled = false;
+    (async () => {
+      for (const pubkey of uniqueSellerPubkeys) {
+        if (cancelled) return;
+        if (discountCodes[pubkey] || affiliateMetaBySeller[pubkey]) continue;
+        try {
+          const res = await fetch(
+            `/api/affiliates/validate?sellerPubkey=${pubkey}&code=${encodeURIComponent(
+              code
+            )}`
+          );
+          if (!res.ok) continue;
+          const aff = await res.json();
+          if (!aff?.valid) continue;
+          let percent = 0;
+          if (aff.buyerDiscountType === "percent") {
+            percent = Number(aff.buyerDiscountValue) || 0;
+          } else if (aff.buyerDiscountType === "fixed") {
+            const sub = getSellerSubtotalInCurrency(pubkey);
+            if (sub > 0) {
+              percent = Math.min(
+                100,
+                (Number(aff.buyerDiscountValue) / sub) * 100
+              );
+            }
+          }
+          if (cancelled) return;
+          setDiscountCodes((p) => ({ ...p, [pubkey]: code }));
+          setAppliedDiscounts((p) => ({ ...p, [pubkey]: percent }));
+          setAffiliateMetaBySeller((p) => ({
+            ...p,
+            [pubkey]: {
+              code,
+              codeId: aff.codeId,
+              affiliateId: aff.affiliateId,
+              rebateType: aff.rebateType,
+              rebateValue: Number(aff.rebateValue) || 0,
+            },
+          }));
+        } catch {}
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [sellerPubkeyKey]);
+
+  useEffect(() => {
     const shippingTypeMap: { [key: string]: ShippingOptionsType } = {};
     products.forEach((product) => {
       if (product.shippingType !== undefined) {
@@ -705,6 +770,50 @@ export default function Component() {
         };
         localStorage.setItem("cartDiscounts", JSON.stringify(discounts));
       } else {
+        const affRes = await fetch(
+          `/api/affiliates/validate?sellerPubkey=${pubkey}&code=${encodeURIComponent(
+            code
+          )}`
+        );
+        const aff = affRes.ok ? await affRes.json() : null;
+        if (aff?.valid) {
+          let percent = 0;
+          if (aff.buyerDiscountType === "percent") {
+            percent = Number(aff.buyerDiscountValue) || 0;
+          } else if (aff.buyerDiscountType === "fixed") {
+            const sellerSubtotal = getSellerSubtotalInCurrency(pubkey);
+            if (sellerSubtotal > 0) {
+              percent = Math.min(
+                100,
+                (Number(aff.buyerDiscountValue) / sellerSubtotal) * 100
+              );
+            }
+          }
+          setAppliedDiscounts({ ...appliedDiscounts, [pubkey]: percent });
+          setAffiliateMetaBySeller({
+            ...affiliateMetaBySeller,
+            [pubkey]: {
+              code,
+              codeId: aff.codeId,
+              affiliateId: aff.affiliateId,
+              rebateType: aff.rebateType,
+              rebateValue: Number(aff.rebateValue) || 0,
+            },
+          });
+          setDiscountErrors({ ...discountErrors, [pubkey]: "" });
+          const discounts = getLocalStorageJson<CartDiscountsMap>(
+            "cartDiscounts",
+            {},
+            {
+              removeOnError: true,
+              removeOnValidationError: true,
+              validate: isCartDiscountsMap,
+            }
+          );
+          discounts[pubkey] = { code };
+          localStorage.setItem("cartDiscounts", JSON.stringify(discounts));
+          return;
+        }
         setDiscountErrors({
           ...discountErrors,
           [pubkey]: "Invalid or expired discount code",
@@ -725,6 +834,11 @@ export default function Component() {
     setDiscountCodes({ ...discountCodes, [pubkey]: "" });
     setAppliedDiscounts({ ...appliedDiscounts, [pubkey]: 0 });
     setDiscountErrors({ ...discountErrors, [pubkey]: "" });
+    setAffiliateMetaBySeller((prev) => {
+      const next = { ...prev };
+      delete next[pubkey];
+      return next;
+    });
 
     // Remove from localStorage
     const discounts = getLocalStorageJson<CartDiscountsMap>(
@@ -1302,6 +1416,7 @@ export default function Component() {
                 subtotalCost={subtotal}
                 appliedDiscounts={appliedDiscounts}
                 discountCodes={discountCodes}
+                affiliateMetaBySeller={affiliateMetaBySeller}
                 shopProfiles={shopContext.shopData}
                 onBackToCart={toggleCheckout}
                 setInvoiceIsPaid={setInvoiceIsPaid}

--- a/pages/cart/index.tsx
+++ b/pages/cart/index.tsx
@@ -36,6 +36,7 @@ import StorefrontThemeWrapper from "@/components/storefront/storefront-theme-wra
 import ProtectedRoute from "@/components/utility-components/protected-route";
 import { getLocalStorageJson } from "@/utils/safe-json";
 import { CartDiscountsMap, isCartDiscountsMap } from "@/utils/cart-discounts";
+import { getAffiliateRefCookie } from "@/components/utility-components/affiliate-ref-tracker";
 
 interface QuantitySelectorProps {
   value: number;
@@ -615,15 +616,16 @@ export default function Component() {
   useEffect(() => {
     if (typeof document === "undefined") return;
     if (uniqueSellerPubkeys.length === 0) return;
-    const m = document.cookie.match(/(?:^|; )mm_aff_ref=([^;]*)/);
-    if (!m) return;
-    const code = decodeURIComponent(m[1]!);
-    if (!code) return;
     let cancelled = false;
     (async () => {
       for (const pubkey of uniqueSellerPubkeys) {
         if (cancelled) return;
         if (discountCodes[pubkey] || affiliateMetaBySeller[pubkey]) continue;
+        // Prefer a code that was set on this seller's storefront over the
+        // wildcard slot, so a code captured on seller A doesn't leak onto
+        // seller B at multi-seller checkout.
+        const code = getAffiliateRefCookie(pubkey);
+        if (!code) continue;
         try {
           const res = await fetch(
             `/api/affiliates/validate?sellerPubkey=${pubkey}&code=${encodeURIComponent(
@@ -731,6 +733,19 @@ export default function Component() {
       return;
     }
 
+    // Mutual exclusivity: a regular discount and an affiliate code can't both
+    // apply to the same seller. If the user already has one active, ask them
+    // to remove it before trying another so they don't get a confusing
+    // silent failure later in the flow.
+    if (appliedDiscounts[pubkey] && affiliateMetaBySeller[pubkey]) {
+      setDiscountErrors({
+        ...discountErrors,
+        [pubkey]:
+          "An affiliate code is already applied. Remove it before adding another code.",
+      });
+      return;
+    }
+
     try {
       const response = await fetch(
         `/api/db/discount-codes?validate=true&code=${encodeURIComponent(
@@ -749,6 +764,12 @@ export default function Component() {
       const result = await response.json();
 
       if (result.valid && result.discount_percentage) {
+        // A regular discount won — clear any previous affiliate attribution
+        // so the order doesn't mistakenly send a rebate to an affiliate.
+        if (affiliateMetaBySeller[pubkey]) {
+          const { [pubkey]: _drop, ...rest } = affiliateMetaBySeller;
+          setAffiliateMetaBySeller(rest);
+        }
         setAppliedDiscounts({
           ...appliedDiscounts,
           [pubkey]: result.discount_percentage,
@@ -770,10 +791,15 @@ export default function Component() {
         };
         localStorage.setItem("cartDiscounts", JSON.stringify(discounts));
       } else {
+        // Pass the seller's order currency so the validate endpoint can
+        // reject fixed-amount codes whose currency doesn't match this cart
+        // (e.g. a USD code on a sats invoice).
+        const sellerCurrency =
+          products.find((p) => p.pubkey === pubkey)?.currency || "usd";
         const affRes = await fetch(
           `/api/affiliates/validate?sellerPubkey=${pubkey}&code=${encodeURIComponent(
             code
-          )}`
+          )}&currency=${encodeURIComponent(sellerCurrency)}`
         );
         const aff = affRes.ok ? await affRes.json() : null;
         if (aff?.valid) {

--- a/replit.md
+++ b/replit.md
@@ -282,3 +282,36 @@ API keys are created via the `/settings/api-keys` UI page, the `/api/mcp/api-key
 - **Turbopack**: Dev server uses Turbopack (Next.js default) instead of webpack for significantly faster compilation (~36s vs ~87s initial, sub-second subsequent).
 - **PWA disabled in dev**: Service worker and PWA caching are disabled via `next.config.mjs` in development.
 - **Flow scheduler disabled in dev**: Email flow scheduler skipped in development to reduce memory pressure.
+
+## Affiliate / Referral System
+
+Seller-managed affiliate links and codes that work for both Stripe and Bitcoin/Cashu payments.
+
+### Data model (`db/schema.sql`, `utils/db/affiliates.ts`)
+
+- `affiliates` — seller-owned affiliate record (name, email, optional pubkey, lightning address, Stripe Connect id, payout schedule, balance, invite token).
+- `affiliate_codes` — one or more codes per affiliate with rebate (percent/fixed) + buyer discount (percent/fixed), expiry, max uses.
+- `affiliate_referrals` — one row per referred order; tracks gross/net/rebate/buyer-discount in smallest units, payment rail, status (pending/payable/paid).
+- `affiliate_payouts` — settled payout batches (Stripe transfer id, lightning preimage, or manual mark-paid).
+
+### API endpoints (`pages/api/affiliates/`)
+
+- `manage` (CRUD seller affiliates), `codes` (CRUD codes), `validate` (public buyer validation), `claim` (affiliate self-service via invite token), `payouts` (seller view), `mark-paid` (manual settlement), `record-referral` (cart calls on order success), `process-payouts` (cron, `Authorization: Bearer $AFFILIATE_PAYOUT_CRON_SECRET`).
+
+### Payment integration
+
+- `pages/api/stripe/create-payment-intent.ts` accepts per-seller `affiliateRebateSmallest`, `affiliateAccountId`, `affiliateId`, `affiliateCodeId`, `affiliateCode`.
+- `pages/api/stripe/process-transfers.ts` caps the rebate (seller keeps ≥1 unit after donation+rebate), subtracts rebate from the seller transfer, and (multi-merchant only) issues a real-time Stripe transfer to the affiliate's connected account when present; otherwise the rebate accrues to the affiliate balance.
+- Cashu/Lightning orders accrue to balance and are paid out by the cron on the affiliate's chosen schedule (every-sale / daily / weekly / monthly).
+
+### UI
+
+- `components/my-listings/affiliates.tsx` — seller dashboard with 4 tabs (Affiliates, Codes, Balances, Payouts), wired into `my-listings.tsx`.
+- `pages/affiliate/[token].tsx` — affiliate self-service page (set lightning address / Stripe Connect id).
+- `components/utility-components/affiliate-ref-tracker.tsx` — mounted in `pages/_app.tsx`; on any `?ref=CODE` URL, drops a 30-day `mm_aff_ref` cookie (SameSite=Lax).
+- `pages/cart/index.tsx` — on cart load, validates the cookie code against each unique seller and pre-fills as a discount; the discount-code input also falls back to affiliate validation if the regular discount lookup fails.
+- `components/cart-invoice-card.tsx` — passes affiliate fields into the payment-intent body and per-seller splits, and POSTs `/api/affiliates/record-referral` after Stripe and Cashu success.
+
+### Env
+
+- `AFFILIATE_PAYOUT_CRON_SECRET` — bearer token guarding `/api/affiliates/process-payouts`.

--- a/replit.md
+++ b/replit.md
@@ -289,29 +289,87 @@ Seller-managed affiliate links and codes that work for both Stripe and Bitcoin/C
 
 ### Data model (`db/schema.sql`, `utils/db/affiliates.ts`)
 
-- `affiliates` — seller-owned affiliate record (name, email, optional pubkey, lightning address, Stripe Connect id, payout schedule, balance, invite token).
-- `affiliate_codes` — one or more codes per affiliate with rebate (percent/fixed) + buyer discount (percent/fixed), expiry, max uses.
-- `affiliate_referrals` — one row per referred order; tracks gross/net/rebate/buyer-discount in smallest units, payment rail, status (pending/payable/paid).
+- `affiliates` — seller-owned affiliate record (name, email, optional pubkey, lightning address, Stripe Connect id, balance, invite token, `payouts_enabled`).
+- `affiliate_codes` — one or more codes per affiliate with rebate (percent/fixed) + buyer discount (percent/fixed), expiry, max uses, and a `payout_schedule` ∈ {`weekly`, `biweekly`, `monthly`} (default `monthly`).
+- `affiliate_referrals` — one row per (order, code); tracks gross/net/rebate/buyer-discount in smallest units, payment rail, status (`pending` → `payable` → `paid`, plus `cancelled`/`refunded`), `refunded_smallest`, `refund_event_ref`. Unique on `(order_id, code_id)` so re-posts are idempotent.
 - `affiliate_payouts` — settled payout batches (Stripe transfer id, lightning preimage, or manual mark-paid).
 
 ### API endpoints (`pages/api/affiliates/`)
 
-- `manage` (CRUD seller affiliates), `codes` (CRUD codes), `validate` (public buyer validation), `claim` (affiliate self-service via invite token), `payouts` (seller view), `mark-paid` (manual settlement), `record-referral` (cart calls on order success), `process-payouts` (cron, `Authorization: Bearer $AFFILIATE_PAYOUT_CRON_SECRET`).
+- `manage` (CRUD seller affiliates), `codes` (CRUD codes), `validate` (public buyer validation), `claim` (affiliate self-service via invite token; signed-pubkey proof required for any update after the first claim), `payouts` (seller view), `mark-paid` (manual settlement), `record-referral` (server-first attribution; atomic max_uses + idempotent), `process-payouts` (cron, `Authorization: Bearer $AFFILIATE_PAYOUT_CRON_SECRET`, advisory-locked per schedule, supports `?dryRun=1`), `self-stats` (token-gated affiliate dashboard data — balances + recent payouts), `stripe-onboarding` (creates a Stripe Express account on the affiliate's behalf and returns an Account Link URL), `ytd-payouts` (seller-scoped year-to-date paid totals with US 1099-NEC threshold flagging at $600).
 
 ### Payment integration
 
 - `pages/api/stripe/create-payment-intent.ts` accepts per-seller `affiliateRebateSmallest`, `affiliateAccountId`, `affiliateId`, `affiliateCodeId`, `affiliateCode`.
-- `pages/api/stripe/process-transfers.ts` caps the rebate (seller keeps ≥1 unit after donation+rebate), subtracts rebate from the seller transfer, and (multi-merchant only) issues a real-time Stripe transfer to the affiliate's connected account when present; otherwise the rebate accrues to the affiliate balance.
-- Cashu/Lightning orders accrue to balance and are paid out by the cron on the affiliate's chosen schedule (every-sale / daily / weekly / monthly).
+- `pages/api/stripe/process-transfers.ts` caps the rebate (seller keeps ≥1 unit after donation+rebate), subtracts rebate from the seller transfer, and calls `recordReferral` server-side (initial status `pending`). Real-time affiliate Stripe transfers were removed so refunds remain reversible during the hold window.
+- `pages/api/stripe/webhook.ts` handles `charge.refunded` and calls `reverseReferralsForOrder`, which cancels still-pending referrals and marks already-paid ones as `refunded` for out-of-band reconciliation.
+- Cashu/Lightning orders accrue to balance via the cart's record-referral call and are paid out by the cron once they age past `PAYOUT_HOLD_DAYS` for their code's schedule.
+
+### Anti-abuse
+
+- Self-referral blocked at both invite-claim time (`updateAffiliatePayoutMethod`) and referral-record time (`record-referral`).
+- `recordReferral` runs in a transaction with `SELECT ... FOR UPDATE` on the code row, enforcing `max_uses` atomically and incrementing `times_used` only on first insert. `ON CONFLICT (order_id, code_id) DO NOTHING` plus a SELECT fallback prevents the browser from overwriting the server-written row.
+- `process-payouts` takes a per-schedule Postgres advisory lock (weekly=91001, biweekly=91002, monthly=91003), enforces a min payout floor (100 sats / 50¢), and skips affiliates with `payouts_enabled = false`.
 
 ### UI
 
-- `components/my-listings/affiliates.tsx` — seller dashboard with 4 tabs (Affiliates, Codes, Balances, Payouts), wired into `my-listings.tsx`.
-- `pages/affiliate/[token].tsx` — affiliate self-service page (set lightning address / Stripe Connect id).
-- `components/utility-components/affiliate-ref-tracker.tsx` — mounted in `pages/_app.tsx`; on any `?ref=CODE` URL, drops a 30-day `mm_aff_ref` cookie (SameSite=Lax).
-- `pages/cart/index.tsx` — on cart load, validates the cookie code against each unique seller and pre-fills as a discount; the discount-code input also falls back to affiliate validation if the regular discount lookup fails.
-- `components/cart-invoice-card.tsx` — passes affiliate fields into the payment-intent body and per-seller splits, and POSTs `/api/affiliates/record-referral` after Stripe and Cashu success.
+- `components/my-listings/affiliates.tsx` — seller dashboard with 4 tabs (Affiliates, Codes, Balances, Payouts), wired into `my-listings.tsx`. Schedule picker is weekly/biweekly/monthly (default monthly).
+- `pages/affiliate/[token].tsx` — affiliate self-service page. Shows per-currency pending/ready/paid balances, a recent-payouts table, and a paused-state warning banner pulled from `/api/affiliates/self-stats`. Includes a "Set up Stripe Connect for me" button that calls `/api/affiliates/stripe-onboarding` to create the Express account and redirect to the Account Link.
+- `components/utility-components/affiliate-ref-tracker.tsx` — mounted in `pages/_app.tsx`; on any `?ref=CODE` URL stores the code in a 30-day `mm_aff_ref` cookie. The cookie is now a JSON map keyed by seller pubkey (with a `*` wildcard fallback) so a code captured on seller A's storefront is preferred for seller A's checkout and won't bleed onto seller B. `?ref_seller=PUBKEY` lets links bind explicitly.
+- `pages/cart/index.tsx` — on cart load, calls `getAffiliateRefCookie(sellerPubkey)` per seller and validates against `/api/affiliates/validate`.
+- `components/cart-invoice-card.tsx` — passes affiliate fields into the payment-intent body and per-seller splits. Cashu success still POSTs `/api/affiliates/record-referral` (server-side enforcement); Stripe success no longer does, since process-transfers + webhook are authoritative.
+
+### Hardening (per-affiliate locks, failure tracking, partial refunds)
+
+- `affiliates` table has `payouts_enabled`, `payout_failure_count`, `last_payout_failure_at`, `last_payout_failure_reason`. After `MAX_PAYOUT_FAILURES` (5) consecutive failures the cron auto-pauses the affiliate.
+- Functional unique index on `(seller_pubkey, UPPER(code))` prevents case-variant code collisions.
+- `process-payouts` now also takes a per-affiliate advisory lock (key `92_000_000 + id`) so two schedules can't double-pay the same affiliate. Each run emits structured `AFFILIATE_PAYOUT_RUN` / `AFFILIATE_PAYOUT_FAILURE` log lines and returns a per-affiliate summary.
+- `manage` endpoint adds a `PUT` action set: `regenerate-token`, `set-payouts-enabled`, and a 409-guarded `force-delete` (refuses while there are unsettled balances unless `force=true`).
+- `claim` GET masks the affiliate's email/lightning/Stripe id once the affiliate has claimed the link, so a leaked invite URL can't reveal contact info.
+- `validate` endpoint enforces a `currency` query param for fixed-amount codes (USD code rejected on a sats invoice and vice versa) and returns a uniform `{ valid: false }` shape on all failures. Cart now passes `currency` per seller.
+- Refund handling is partial-refund aware: `reverseReferralsForOrder` consumes `originalGrossSmallest` from the Stripe webhook, computes a refund ratio, and scales pending rebates proportionally; already-paid rebates are recorded as clawbacks for out-of-band reconciliation.
+- Pure helpers (`computeRefundRatio`, `computeClawbackSmallest`, `computeBuyerDiscountSmallest`, `computeRebateSmallest`, `isSelfReferral`) are covered by `__tests__/utils/db/affiliates.test.ts`.
+- `scripts/reconcile-affiliate-balances.ts` is a standalone CLI (`pnpm tsx scripts/reconcile-affiliate-balances.ts [--apply]`) that recomputes per-affiliate per-currency balances and flags orphan paid rows, refund overshoots, and stale payable rows.
+- Stripe payout idempotency is a stable SHA-256 of `(affiliateId, currency, amount, sorted referralIds)` (key format `aff-payout-{id}-{hash32}`), so a cron crash followed by a retry returns the original transfer instead of double-paying. The same hash is also stored as `bundleDigest` in Stripe transfer metadata for forensic lookup.
+- `process-payouts` sends `affiliatePaidEmail` on every successful Stripe payout, plus one-time `affiliatePausedToAffiliateEmail` and `affiliatePausedToSellerEmail` notifications the moment `MAX_PAYOUT_FAILURES` flips an affiliate's `payouts_enabled` to `false`. Seller emails are looked up via `getSellerEmailForPubkey` (a thin wrapper around `getSellerNotificationEmail`).
+- **Partial-refund caveat**: when a single Stripe charge spans multiple sellers, the webhook does not break the refund down per seller. `reverseReferralsForOrder` applies a global refund ratio (`refunded / original_gross`) to every pending rebate on the order. In the rare case where a buyer refunds only one seller's portion of a multi-seller cart, the resulting clawback is best-effort and must be reconciled manually using the Stripe dashboard. Documented at `docs/affiliate-payout-cron.md`.
+
+### Scheduled deployment setup
+
+`.replit` is read-only in this environment, so the affiliate payout crons are documented at `docs/affiliate-payout-cron.md` instead of being declared inline. Configure three Replit Scheduled Deployments — weekly (`0 14 * * 1`), biweekly (`0 14 1,15 * *`), and monthly (`0 14 1 * *`) — each running:
+
+```sh
+curl -fsSL -X POST \
+  -H "Authorization: Bearer $AFFILIATE_PAYOUT_CRON_SECRET" \
+  "$NEXT_PUBLIC_BASE_URL/api/affiliates/process-payouts?schedule=<weekly|biweekly|monthly>"
+```
+
+### Tests
+
+- `__tests__/utils/db/affiliates.test.ts` covers the pure helpers.
+- `__tests__/api/affiliates/validate.test.ts` covers the public validation endpoint, including the fixed-amount currency guard and the uniform `{ valid: false }` failure shape.
+- `__tests__/api/affiliates/record-referral.test.ts` covers self-referral blocking, currency-mismatch rejection, the happy path (returns computed amounts and writes with `initialStatus: 'pending'`), and the 409 surface for `max_uses` contention.
+
+### Click tracking, unsubscribe, and reverse-referral
+
+- `affiliate_clicks` table records `(code_id, seller_pubkey, occurred_at)` only — no IPs, no user-agents. The public `record-click` endpoint always returns 200 (silently swallows errors so client-side noise can never leak rate-limit info), and `affiliate-ref-tracker.tsx` POSTs at most once per session via `sessionStorage`.
+- `click-stats` (signed seller request) returns a 30-day click × conversion table per code via FULL OUTER JOIN, so codes with clicks-but-no-conversions and conversions-but-no-clicks both surface. The dashboard Analytics tab also derives YTD paid-out locally from the payouts feed.
+- `reverse-referral` is the seller-only manual clawback. It enforces `pubkey === sellerPubkey` (signed-event auth), takes an `orderId` + optional `reason`, and reuses `reverseReferralsForOrder` so partial-refund math stays consistent.
+- `unsubscribe` is RFC 8058 one-click. Affiliate emails (`affiliatePaidEmail`, `affiliatePausedToAffiliateEmail`) emit `List-Unsubscribe` + `List-Unsubscribe-Post: List-Unsubscribe=One-Click` headers and a footer link, both built from `mintAffiliateUnsubscribeToken` (HMAC, requires `AFFILIATE_UNSUBSCRIBE_SECRET`). Hitting the URL flips `affiliates.email_notifications_enabled = false`; the cron then skips that affiliate's notifications without affecting payouts.
+- The Stripe webhook handles `account.updated` and mirrors `charges_enabled` / `payouts_enabled` / `details_submitted` into `affiliates` via `syncAffiliateStripeAccountState`, so a Connect account that loses payouts capability automatically stops getting Stripe transfers on the next cron run. Unknown accounts (Connect accounts not linked to any affiliate) no-op silently — the `UPDATE` simply touches zero rows.
+
+### Privacy & retention
+
+- `affiliate_clicks` is **PII-free by design**: only `(code_id, seller_pubkey, occurred_at, optional landing_path, optional referer_host)` are stored. No IPs, no user-agents, no cookies, no fingerprints. Future contributors must not add identifying columns without a privacy review and an updated public privacy notice.
+- Unsubscribe tokens carry an issued-at timestamp and expire after 1 year (`UNSUBSCRIBE_TOKEN_TTL_MS` in `utils/email/unsubscribe-tokens.ts`). Rotating `AFFILIATE_UNSUBSCRIBE_SECRET` invalidates every outstanding link at once.
+
+### Operator runbook
+
+- **Reverse a referral / clawback a rebate**: open the seller dashboard → Affiliates → Analytics tab → "Reverse referral" form. Enter the order id and (optionally) a reason. This calls `/api/affiliates/reverse-referral` with the seller's signed Nostr event; the route applies `reverseReferralsForOrder` so pending rebates are scaled and already-paid rebates are recorded as clawbacks for out-of-band reconciliation.
+- **Unsubscribe an affiliate from emails**: every affiliate email contains a one-click unsubscribe link. Operators can also POST to `/api/affiliates/unsubscribe` with a token minted by `mintAffiliateUnsubscribeToken(id)`. Re-subscribing requires updating `affiliates.email_notifications_enabled = true` directly in the DB (intentional — there is no public re-subscribe surface).
+- **Stripe Connect goes cold**: nothing to do — `account.updated` webhooks flip the affiliate's flags automatically, and the next cron pass logs `payouts disabled` for the affected affiliate.
 
 ### Env
 
 - `AFFILIATE_PAYOUT_CRON_SECRET` — bearer token guarding `/api/affiliates/process-payouts`.
+- `AFFILIATE_UNSUBSCRIBE_SECRET` — HMAC key (≥16 chars) used to mint and verify one-click unsubscribe tokens. Required for the `unsubscribe` route and for any affiliate email that includes `List-Unsubscribe` headers.

--- a/scripts/reconcile-affiliate-balances.ts
+++ b/scripts/reconcile-affiliate-balances.ts
@@ -1,0 +1,134 @@
+/**
+ * Affiliate balance reconciliation CLI.
+ *
+ * Usage:
+ *   pnpm tsx scripts/reconcile-affiliate-balances.ts            # report only
+ *   pnpm tsx scripts/reconcile-affiliate-balances.ts --apply    # apply fixes
+ *
+ * What it does:
+ *   1. Recomputes per-affiliate per-currency totals from the referrals table
+ *      and prints a side-by-side report against the live aggregates that the
+ *      seller dashboard renders.
+ *   2. Detects a few invariants we rely on elsewhere and reports violations:
+ *        - paid referral with no payout_id
+ *        - payable referral older than its hold window with no payout
+ *        - refund ledger row whose refunded_smallest exceeds rebate_smallest
+ *   3. With --apply, fixes the first invariant by demoting orphan 'paid'
+ *      rows back to 'payable' so the next cron picks them up. Other
+ *      invariants are reported only because they require human judgment.
+ */
+import { getDbPool } from "@/utils/db/db-service";
+
+type Row = {
+  affiliate_id: number;
+  affiliate_name: string;
+  currency: string;
+  pending_smallest: string;
+  payable_smallest: string;
+  paid_smallest: string;
+  paid_with_payout: string;
+};
+
+async function main() {
+  const apply = process.argv.includes("--apply");
+  const pool = getDbPool();
+  const client = await pool.connect();
+  try {
+    const totals = await client.query<Row>(
+      `SELECT
+         r.affiliate_id,
+         a.name AS affiliate_name,
+         r.currency,
+         COALESCE(SUM(CASE WHEN status='pending' THEN rebate_smallest ELSE 0 END),0)::text AS pending_smallest,
+         COALESCE(SUM(CASE WHEN status='payable' THEN rebate_smallest ELSE 0 END),0)::text AS payable_smallest,
+         COALESCE(SUM(CASE WHEN status='paid' THEN rebate_smallest ELSE 0 END),0)::text AS paid_smallest,
+         COALESCE(SUM(CASE WHEN status='paid' AND payout_id IS NOT NULL THEN rebate_smallest ELSE 0 END),0)::text AS paid_with_payout
+       FROM affiliate_referrals r
+       JOIN affiliates a ON a.id = r.affiliate_id
+       GROUP BY r.affiliate_id, a.name, r.currency
+       ORDER BY a.name, r.currency`
+    );
+
+    console.log(
+      `\n=== Affiliate balances (${totals.rowCount ?? 0} buckets) ===`
+    );
+    for (const r of totals.rows) {
+      const drift = Number(r.paid_smallest) - Number(r.paid_with_payout);
+      console.log(
+        `${r.affiliate_name} [${r.currency}] ` +
+          `pending=${r.pending_smallest} payable=${r.payable_smallest} ` +
+          `paid=${r.paid_smallest}` +
+          (drift !== 0 ? ` (drift=${drift})` : "")
+      );
+    }
+
+    // Invariant 1: paid rows missing a payout_id (orphaned)
+    const orphans = await client.query(
+      `SELECT id, affiliate_id, order_id, rebate_smallest, currency
+         FROM affiliate_referrals
+         WHERE status = 'paid' AND payout_id IS NULL`
+    );
+    if ((orphans.rowCount ?? 0) > 0) {
+      console.log(`\n[!] Orphan paid referrals: ${orphans.rowCount}`);
+      orphans.rows.forEach((r) =>
+        console.log(
+          `    id=${r.id} affiliate=${r.affiliate_id} order=${r.order_id}`
+        )
+      );
+      if (apply) {
+        const fix = await client.query(
+          `UPDATE affiliate_referrals
+             SET status = 'payable', updated_at = CURRENT_TIMESTAMP
+           WHERE status = 'paid' AND payout_id IS NULL
+           RETURNING id`
+        );
+        console.log(`    -> demoted ${fix.rowCount} row(s) back to payable`);
+      } else {
+        console.log("    (run with --apply to demote them back to payable)");
+      }
+    }
+
+    // Invariant 2: refunded_smallest > rebate_smallest (overshoot)
+    const overshoot = await client.query(
+      `SELECT id, affiliate_id, order_id, rebate_smallest, refunded_smallest
+         FROM affiliate_referrals
+         WHERE refunded_smallest > rebate_smallest`
+    );
+    if ((overshoot.rowCount ?? 0) > 0) {
+      console.log(
+        `\n[!] Refund overshoot rows: ${overshoot.rowCount} (manual review needed)`
+      );
+      overshoot.rows.forEach((r) =>
+        console.log(
+          `    id=${r.id} order=${r.order_id} rebate=${r.rebate_smallest} refunded=${r.refunded_smallest}`
+        )
+      );
+    }
+
+    // Invariant 3: payable rows older than 60 days with no payout
+    const stale = await client.query(
+      `SELECT id, affiliate_id, order_id, currency, rebate_smallest, created_at
+         FROM affiliate_referrals
+         WHERE status = 'payable' AND payout_id IS NULL
+           AND created_at < NOW() - INTERVAL '60 days'`
+    );
+    if ((stale.rowCount ?? 0) > 0) {
+      console.log(`\n[!] Stale payable referrals (>60d): ${stale.rowCount}`);
+      stale.rows.forEach((r) =>
+        console.log(
+          `    id=${r.id} affiliate=${r.affiliate_id} created=${r.created_at.toISOString?.() ?? r.created_at}`
+        )
+      );
+    }
+
+    console.log("\nDone.");
+  } finally {
+    client.release();
+    await pool.end();
+  }
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/utils/db/affiliates.ts
+++ b/utils/db/affiliates.ts
@@ -3,10 +3,27 @@ import { getDbPool } from "@/utils/db/db-service";
 
 export type RebateType = "percent" | "fixed";
 export type DiscountType = "percent" | "fixed";
-export type PayoutSchedule = "every_sale" | "daily" | "weekly" | "monthly";
-export type ReferralStatus = "pending" | "payable" | "paid" | "cancelled";
+// Real-time payouts were removed so refund clawbacks are deterministic.
+// All rebates accrue and settle in batch on the chosen cadence.
+export type PayoutSchedule = "weekly" | "biweekly" | "monthly";
+export type ReferralStatus =
+  | "pending"
+  | "payable"
+  | "paid"
+  | "cancelled"
+  | "refunded";
 export type PaymentRail = "stripe" | "bitcoin";
 export type PayoutMethod = "stripe" | "lightning" | "manual";
+
+// Minimum age (days) a referral must reach before it becomes 'payable'. This
+// gives buyers a refund window and keeps clawbacks simple — once a referral
+// is promoted past this it can be paid by the cron and any later refund
+// flips the row to 'refunded' for manual reconciliation.
+export const PAYOUT_HOLD_DAYS: Record<PayoutSchedule, number> = {
+  weekly: 7,
+  biweekly: 14,
+  monthly: 30,
+};
 
 export interface Affiliate {
   id: number;
@@ -19,9 +36,22 @@ export interface Affiliate {
   lightning_address: string | null;
   stripe_account_id: string | null;
   notes: string | null;
+  payouts_enabled: boolean;
+  payout_failure_count: number;
+  last_payout_failure_at: Date | null;
+  last_payout_failure_reason: string | null;
+  email_notifications_enabled: boolean;
+  stripe_charges_enabled: boolean;
+  stripe_payouts_enabled: boolean;
+  stripe_onboarding_complete: boolean;
   created_at: Date;
   updated_at: Date;
 }
+
+// Hard cap on how many consecutive automated payout attempts we make for a
+// single affiliate before flipping `payouts_enabled` off. After that the
+// seller must investigate (e.g. wrong lightning address) and re-enable.
+export const MAX_PAYOUT_FAILURES = 5;
 
 export interface AffiliateCode {
   id: number;
@@ -209,6 +239,18 @@ export async function updateAffiliatePayoutMethod(
   const pool = getDbPool();
   const client = await pool.connect();
   try {
+    // Block a seller from claiming their own affiliate invite — that would
+    // let them rebate themselves on every sale.
+    if (patch.affiliatePubkey) {
+      const owner = await client.query(
+        `SELECT seller_pubkey FROM affiliates WHERE invite_token = $1`,
+        [inviteToken]
+      );
+      const sellerPubkey = owner.rows[0]?.seller_pubkey as string | undefined;
+      if (sellerPubkey && isSelfReferral(sellerPubkey, patch.affiliatePubkey)) {
+        throw new Error("Sellers cannot claim their own affiliate invite");
+      }
+    }
     const fields: string[] = [];
     const values: unknown[] = [];
     let i = 1;
@@ -241,16 +283,152 @@ export async function updateAffiliatePayoutMethod(
   }
 }
 
+/**
+ * Delete an affiliate. Refuses when the affiliate has any unsettled balance
+ * (pending or payable referrals) unless `force` is set, in which case those
+ * referrals are first cancelled. This guards the seller from accidentally
+ * deleting an affiliate they still owe money to.
+ */
 export async function deleteAffiliate(
   id: number,
+  sellerPubkey: string,
+  opts: { force?: boolean } = {}
+): Promise<void> {
+  const pool = getDbPool();
+  const client = await pool.connect();
+  try {
+    await client.query("BEGIN");
+    const bal = await client.query(
+      `SELECT COALESCE(SUM(rebate_smallest), 0)::text AS owed
+         FROM affiliate_referrals
+         WHERE affiliate_id = $1 AND seller_pubkey = $2
+           AND status IN ('pending', 'payable')`,
+      [id, sellerPubkey]
+    );
+    const owed = Number(bal.rows[0]?.owed ?? 0);
+    if (owed > 0 && !opts.force) {
+      await client.query("ROLLBACK");
+      throw new Error(
+        `Affiliate has an unsettled balance (${owed}). Pay it out or pass force=true to cancel and delete.`
+      );
+    }
+    if (opts.force && owed > 0) {
+      await client.query(
+        `UPDATE affiliate_referrals
+           SET status = 'cancelled', updated_at = CURRENT_TIMESTAMP
+         WHERE affiliate_id = $1 AND seller_pubkey = $2
+           AND status IN ('pending', 'payable')`,
+        [id, sellerPubkey]
+      );
+    }
+    await client.query(
+      `DELETE FROM affiliates WHERE id = $1 AND seller_pubkey = $2`,
+      [id, sellerPubkey]
+    );
+    await client.query("COMMIT");
+  } catch (err) {
+    try {
+      await client.query("ROLLBACK");
+    } catch {}
+    throw err;
+  } finally {
+    client.release();
+  }
+}
+
+/**
+ * Rotate the affiliate's invite token (e.g. when the previous link leaks).
+ * Returns the new token. The caller has already authenticated as the seller.
+ */
+export async function regenerateInviteToken(
+  id: number,
   sellerPubkey: string
+): Promise<string | null> {
+  const pool = getDbPool();
+  const client = await pool.connect();
+  try {
+    const newToken = generateInviteToken();
+    const r = await client.query(
+      `UPDATE affiliates
+         SET invite_token = $1, updated_at = CURRENT_TIMESTAMP
+       WHERE id = $2 AND seller_pubkey = $3
+       RETURNING invite_token`,
+      [newToken, id, sellerPubkey]
+    );
+    return (r.rows[0]?.invite_token as string) ?? null;
+  } finally {
+    client.release();
+  }
+}
+
+/**
+ * Toggle payouts_enabled on an affiliate. Used by the seller to re-enable
+ * auto-payouts after a failure has been investigated.
+ */
+export async function setAffiliatePayoutsEnabled(
+  id: number,
+  sellerPubkey: string,
+  enabled: boolean
+): Promise<Affiliate | null> {
+  const pool = getDbPool();
+  const client = await pool.connect();
+  try {
+    const r = await client.query(
+      `UPDATE affiliates
+         SET payouts_enabled = $1,
+             payout_failure_count = CASE WHEN $1 THEN 0 ELSE payout_failure_count END,
+             last_payout_failure_reason = CASE WHEN $1 THEN NULL ELSE last_payout_failure_reason END,
+             updated_at = CURRENT_TIMESTAMP
+       WHERE id = $2 AND seller_pubkey = $3
+       RETURNING *`,
+      [enabled, id, sellerPubkey]
+    );
+    return (r.rows[0] as Affiliate) ?? null;
+  } finally {
+    client.release();
+  }
+}
+
+/**
+ * Record a failed payout attempt; flips `payouts_enabled` off once the
+ * cumulative failure count crosses MAX_PAYOUT_FAILURES.
+ */
+export async function recordPayoutFailure(
+  affiliateId: number,
+  reason: string
 ): Promise<void> {
   const pool = getDbPool();
   const client = await pool.connect();
   try {
     await client.query(
-      `DELETE FROM affiliates WHERE id = $1 AND seller_pubkey = $2`,
-      [id, sellerPubkey]
+      `UPDATE affiliates
+         SET payout_failure_count = payout_failure_count + 1,
+             last_payout_failure_at = CURRENT_TIMESTAMP,
+             last_payout_failure_reason = $2,
+             payouts_enabled = CASE
+               WHEN payout_failure_count + 1 >= $3 THEN FALSE
+               ELSE payouts_enabled
+             END,
+             updated_at = CURRENT_TIMESTAMP
+       WHERE id = $1`,
+      [affiliateId, reason.slice(0, 500), MAX_PAYOUT_FAILURES]
+    );
+  } finally {
+    client.release();
+  }
+}
+
+export async function clearPayoutFailure(affiliateId: number): Promise<void> {
+  const pool = getDbPool();
+  const client = await pool.connect();
+  try {
+    await client.query(
+      `UPDATE affiliates
+         SET payout_failure_count = 0,
+             last_payout_failure_reason = NULL,
+             updated_at = CURRENT_TIMESTAMP
+       WHERE id = $1`,
+      [affiliateId]
     );
   } finally {
     client.release();
@@ -444,19 +622,42 @@ export async function isAffiliateCodeValid(c: AffiliateCode): Promise<boolean> {
   return true;
 }
 
+/**
+ * Atomic max_uses enforcement: only increments if there is still room under
+ * `max_uses` (or if `max_uses` is null). Returns true on success so the
+ * caller can roll back / refuse the referral when the cap is reached.
+ */
 export async function incrementAffiliateCodeUsage(
   codeId: number
-): Promise<void> {
+): Promise<boolean> {
   const pool = getDbPool();
   const client = await pool.connect();
   try {
-    await client.query(
-      `UPDATE affiliate_codes SET times_used = times_used + 1, updated_at = CURRENT_TIMESTAMP WHERE id = $1`,
+    const r = await client.query(
+      `UPDATE affiliate_codes
+         SET times_used = times_used + 1, updated_at = CURRENT_TIMESTAMP
+       WHERE id = $1
+         AND is_active = TRUE
+         AND (max_uses IS NULL OR times_used < max_uses)
+       RETURNING id`,
       [codeId]
     );
+    return (r.rowCount ?? 0) > 0;
   } finally {
     client.release();
   }
+}
+
+/**
+ * Returns true if the affiliate is the seller themselves — used to block
+ * obvious self-referral abuse at create / claim / record time.
+ */
+export function isSelfReferral(
+  sellerPubkey: string,
+  affiliatePubkey: string | null | undefined
+): boolean {
+  if (!affiliatePubkey) return false;
+  return affiliatePubkey.toLowerCase() === sellerPubkey.toLowerCase();
 }
 
 // ---------------------------------------------------------------------------
@@ -527,16 +728,26 @@ export async function recordReferral(params: {
   const pool = getDbPool();
   const client = await pool.connect();
   try {
-    const result = await client.query(
+    await client.query("BEGIN");
+    // Lock the code row so concurrent callers see a consistent times_used.
+    const codeRes = await client.query(
+      `SELECT is_active, max_uses, times_used FROM affiliate_codes
+         WHERE id = $1 FOR UPDATE`,
+      [params.codeId]
+    );
+    if (codeRes.rowCount === 0 || !codeRes.rows[0].is_active) {
+      throw new Error("Affiliate code is inactive or missing");
+    }
+    const { max_uses, times_used } = codeRes.rows[0];
+    // Idempotency-safe insert: DO NOTHING on conflict so a late call from
+    // the browser cannot overwrite the row written by the Stripe webhook.
+    const insRes = await client.query(
       `INSERT INTO affiliate_referrals
          (affiliate_id, code_id, seller_pubkey, order_id, payment_rail,
           gross_subtotal_smallest, buyer_discount_smallest, rebate_smallest,
           currency, status, realtime_transfer_ref)
        VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11)
-       ON CONFLICT (order_id, code_id) DO UPDATE SET
-         status = EXCLUDED.status,
-         realtime_transfer_ref = COALESCE(EXCLUDED.realtime_transfer_ref, affiliate_referrals.realtime_transfer_ref),
-         updated_at = CURRENT_TIMESTAMP
+       ON CONFLICT (order_id, code_id) DO NOTHING
        RETURNING *`,
       [
         params.affiliateId,
@@ -552,7 +763,44 @@ export async function recordReferral(params: {
         params.realtimeTransferRef ?? null,
       ]
     );
-    return result.rows[0] as AffiliateReferral;
+    let referral: AffiliateReferral;
+    let inserted = false;
+    if ((insRes.rowCount ?? 0) > 0) {
+      // Enforce max_uses inside the same transaction so two concurrent
+      // referrals can't both fit under the cap.
+      if (max_uses !== null && times_used >= max_uses) {
+        await client.query("ROLLBACK");
+        throw new Error("Affiliate code is no longer available");
+      }
+      await client.query(
+        `UPDATE affiliate_codes
+           SET times_used = times_used + 1, updated_at = CURRENT_TIMESTAMP
+         WHERE id = $1`,
+        [params.codeId]
+      );
+      referral = insRes.rows[0] as AffiliateReferral;
+      inserted = true;
+    } else {
+      const sel = await client.query(
+        `SELECT * FROM affiliate_referrals
+           WHERE order_id = $1 AND code_id = $2`,
+        [params.orderId, params.codeId]
+      );
+      referral = sel.rows[0] as AffiliateReferral;
+    }
+    await client.query("COMMIT");
+    // The `inserted` flag is exposed via a non-enumerable property so the
+    // existing return type stays a plain referral row for back-compat.
+    Object.defineProperty(referral, "_inserted", {
+      value: inserted,
+      enumerable: false,
+    });
+    return referral;
+  } catch (err) {
+    try {
+      await client.query("ROLLBACK");
+    } catch {}
+    throw err;
   } finally {
     client.release();
   }
@@ -622,7 +870,9 @@ export async function getAffiliateBalances(
 
 /**
  * Move all eligible referrals for an affiliate (matching schedule + currency)
- * to status='payable' so the scheduler picks them up.
+ * to status='payable' so the scheduler picks them up. Referrals are only
+ * promoted once they are older than the schedule's hold window — this gives
+ * buyers a refund window before money leaves the platform.
  */
 export async function markReferralsPayableBySchedule(
   schedule: PayoutSchedule
@@ -630,16 +880,511 @@ export async function markReferralsPayableBySchedule(
   const pool = getDbPool();
   const client = await pool.connect();
   try {
+    const holdDays = PAYOUT_HOLD_DAYS[schedule];
     const r = await client.query(
       `UPDATE affiliate_referrals AS r
          SET status = 'payable', updated_at = CURRENT_TIMESTAMP
        FROM affiliate_codes c
        WHERE r.code_id = c.id
          AND c.payout_schedule = $1
-         AND r.status = 'pending'`,
-      [schedule]
+         AND r.status = 'pending'
+         AND r.created_at <= NOW() - ($2::int || ' days')::interval`,
+      [schedule, holdDays]
     );
     return r.rowCount ?? 0;
+  } finally {
+    client.release();
+  }
+}
+
+/**
+ * Pure helper: compute the refund ratio applied to a charge. Clamped 0..1.
+ * Exposed for unit tests.
+ */
+export function computeRefundRatio(
+  originalGrossSmallest: number,
+  refundedSmallest: number
+): number {
+  if (!Number.isFinite(originalGrossSmallest) || originalGrossSmallest <= 0) {
+    return 0;
+  }
+  if (!Number.isFinite(refundedSmallest) || refundedSmallest <= 0) return 0;
+  return Math.min(1, refundedSmallest / originalGrossSmallest);
+}
+
+/**
+ * Pure helper: scale an original rebate down by the refund ratio. Returns the
+ * portion of the rebate that has been clawed back. Exposed for unit tests.
+ */
+export function computeClawbackSmallest(
+  originalRebateSmallest: number,
+  refundRatio: number
+): number {
+  if (!Number.isFinite(originalRebateSmallest) || originalRebateSmallest <= 0) {
+    return 0;
+  }
+  const r = Math.max(0, Math.min(1, refundRatio));
+  return Math.floor(originalRebateSmallest * r);
+}
+
+/**
+ * Refund/clawback: cancel or scale-down pending/payable referrals (no money
+ * has moved yet) and mark already-paid referrals as 'refunded' so the seller
+ * can reconcile manually with the affiliate. Used by the Stripe
+ * `charge.refunded` webhook.
+ *
+ * Partial refund handling:
+ *  - When `originalGrossSmallest` is provided we compute a refund ratio and
+ *    scale each referral's rebate proportionally instead of full-cancelling.
+ *  - For pending/payable rows: rebate is reduced by the clawback amount; if
+ *    the row is fully refunded the status flips to 'cancelled', otherwise it
+ *    remains pending/payable with the smaller rebate.
+ *  - For already-paid rows: we record the proportional clawback in
+ *    `refunded_smallest` for manual reconciliation. Status only flips to
+ *    'refunded' on a full refund.
+ *
+ * When `originalGrossSmallest` is omitted we fall back to the legacy
+ * full-refund behavior for back-compat.
+ */
+export async function reverseReferralsForOrder(params: {
+  orderId: string;
+  sellerPubkey: string;
+  originalGrossSmallest?: number;
+  refundedSmallest?: number;
+  refundEventRef?: string | null;
+}): Promise<{
+  cancelled: number;
+  refunded: number;
+  partial: number;
+  totalClawbackSmallest: number;
+}> {
+  const pool = getDbPool();
+  const client = await pool.connect();
+  try {
+    await client.query("BEGIN");
+
+    const refunded = params.refundedSmallest ?? 0;
+    const gross = params.originalGrossSmallest ?? 0;
+    const ratio =
+      gross > 0 ? computeRefundRatio(gross, refunded) : refunded > 0 ? 1 : 1;
+    const isFull = ratio >= 1 || gross <= 0;
+
+    // Lock + read all candidate rows so we can decide row-by-row.
+    const rowsRes = await client.query(
+      `SELECT id, status, rebate_smallest, refunded_smallest
+         FROM affiliate_referrals
+         WHERE order_id = $1 AND seller_pubkey = $2
+           AND status IN ('pending', 'payable', 'paid')
+         FOR UPDATE`,
+      [params.orderId, params.sellerPubkey]
+    );
+
+    let cancelled = 0;
+    let refundedCount = 0;
+    let partial = 0;
+    let totalClawback = 0;
+
+    for (const row of rowsRes.rows) {
+      const origRebate = Number(row.rebate_smallest);
+      const clawback = isFull
+        ? origRebate
+        : computeClawbackSmallest(origRebate, ratio);
+      totalClawback += clawback;
+
+      if (row.status === "paid") {
+        if (isFull) {
+          await client.query(
+            `UPDATE affiliate_referrals
+               SET status = 'refunded',
+                   refunded_smallest = $2,
+                   refund_event_ref = $3,
+                   updated_at = CURRENT_TIMESTAMP
+             WHERE id = $1`,
+            [row.id, clawback, params.refundEventRef ?? null]
+          );
+          refundedCount += 1;
+        } else {
+          // Partial refund of an already-paid referral. Leave status='paid'
+          // (money already moved) but record the clawback so the seller can
+          // reconcile out-of-band with the affiliate.
+          await client.query(
+            `UPDATE affiliate_referrals
+               SET refunded_smallest = refunded_smallest + $2,
+                   refund_event_ref = $3,
+                   updated_at = CURRENT_TIMESTAMP
+             WHERE id = $1`,
+            [row.id, clawback, params.refundEventRef ?? null]
+          );
+          partial += 1;
+        }
+        continue;
+      }
+
+      // pending / payable
+      if (isFull || clawback >= origRebate) {
+        await client.query(
+          `UPDATE affiliate_referrals
+             SET status = 'cancelled',
+                 refunded_smallest = $2,
+                 refund_event_ref = $3,
+                 updated_at = CURRENT_TIMESTAMP
+           WHERE id = $1`,
+          [
+            row.id,
+            isFull ? origRebate : clawback,
+            params.refundEventRef ?? null,
+          ]
+        );
+        cancelled += 1;
+      } else {
+        // Partial: reduce the rebate so only the unrefunded slice is paid.
+        const newRebate = Math.max(origRebate - clawback, 0);
+        await client.query(
+          `UPDATE affiliate_referrals
+             SET rebate_smallest = $2,
+                 refunded_smallest = refunded_smallest + $3,
+                 refund_event_ref = $4,
+                 updated_at = CURRENT_TIMESTAMP
+           WHERE id = $1`,
+          [row.id, newRebate, clawback, params.refundEventRef ?? null]
+        );
+        partial += 1;
+      }
+    }
+
+    await client.query("COMMIT");
+    return {
+      cancelled,
+      refunded: refundedCount,
+      partial,
+      totalClawbackSmallest: totalClawback,
+    };
+  } catch (err) {
+    await client.query("ROLLBACK");
+    throw err;
+  } finally {
+    client.release();
+  }
+}
+
+/**
+ * Acquire a session-scoped Postgres advisory lock so concurrent cron
+ * invocations of `process-payouts` for the same schedule don't double-pay.
+ * The caller must release the lock by ending the session (we use a fresh
+ * client and release it). Returns null if the lock could not be acquired.
+ */
+export async function tryAdvisoryLock(
+  key: number
+): Promise<{ release: () => Promise<void> } | null> {
+  const pool = getDbPool();
+  const client = await pool.connect();
+  try {
+    const r = await client.query("SELECT pg_try_advisory_lock($1) AS ok", [
+      key,
+    ]);
+    if (!r.rows[0]?.ok) {
+      client.release();
+      return null;
+    }
+    return {
+      release: async () => {
+        try {
+          await client.query("SELECT pg_advisory_unlock($1)", [key]);
+        } finally {
+          client.release();
+        }
+      },
+    };
+  } catch (err) {
+    client.release();
+    throw err;
+  }
+}
+
+// Thin re-export so that affiliate code paths don't have to know about the
+// notification-emails table directly. We import lazily to avoid creating an
+// import cycle through db-service.
+export async function getSellerEmailForPubkey(
+  pubkey: string
+): Promise<string | null> {
+  const mod = await import("@/utils/db/db-service");
+  return mod.getSellerNotificationEmail(pubkey);
+}
+
+// ---------------------------------------------------------------------------
+// Click-through tracking
+// ---------------------------------------------------------------------------
+
+/**
+ * Record a single affiliate-link impression. Called by `/api/affiliates/
+ * record-click` when the front-end ref-tracker first sees `?ref=CODE`. We
+ * intentionally don't store IP or user-agent fingerprints; the seller only
+ * cares about clicks-vs-conversions, not who clicked.
+ */
+export async function recordAffiliateClick(params: {
+  sellerPubkey: string;
+  code: string;
+  landingPath?: string | null;
+  refererHost?: string | null;
+}): Promise<void> {
+  const pool = getDbPool();
+  const client = await pool.connect();
+  try {
+    await client.query(
+      `INSERT INTO affiliate_clicks
+         (seller_pubkey, code, landing_path, referer_host)
+       VALUES ($1, $2, $3, $4)`,
+      [
+        params.sellerPubkey,
+        params.code,
+        params.landingPath ?? null,
+        params.refererHost ?? null,
+      ]
+    );
+  } finally {
+    client.release();
+  }
+}
+
+export interface AffiliateClickAggregate {
+  affiliate_id: number | null;
+  affiliate_name: string | null;
+  code: string;
+  clicks: number;
+  conversions: number;
+  conversion_rate: number;
+}
+
+/**
+ * Per-code click + conversion aggregates for a single seller in a window.
+ * Conversions come from non-cancelled referrals so refunded ones still count
+ * as a real conversion event (the buyer did complete checkout).
+ */
+export async function getAffiliateClickStats(
+  sellerPubkey: string,
+  sinceDays = 30
+): Promise<AffiliateClickAggregate[]> {
+  const pool = getDbPool();
+  const client = await pool.connect();
+  try {
+    const r = await client.query(
+      `WITH click_agg AS (
+         SELECT UPPER(code) AS code_u, COUNT(*)::int AS clicks
+           FROM affiliate_clicks
+           WHERE seller_pubkey = $1
+             AND created_at >= NOW() - ($2::int * INTERVAL '1 day')
+           GROUP BY UPPER(code)
+       ),
+       conv_agg AS (
+         SELECT UPPER(c.code) AS code_u, c.id AS code_id, c.affiliate_id,
+                a.name AS affiliate_name,
+                COUNT(r.id) FILTER (WHERE r.status <> 'cancelled')::int AS conversions
+           FROM affiliate_codes c
+           JOIN affiliates a ON a.id = c.affiliate_id
+           LEFT JOIN affiliate_referrals r ON r.code_id = c.id
+            AND r.created_at >= NOW() - ($2::int * INTERVAL '1 day')
+           WHERE c.seller_pubkey = $1
+           GROUP BY UPPER(c.code), c.id, c.affiliate_id, a.name
+       )
+       SELECT COALESCE(conv.affiliate_id, NULL) AS affiliate_id,
+              COALESCE(conv.affiliate_name, NULL) AS affiliate_name,
+              COALESCE(conv.code_u, click.code_u) AS code,
+              COALESCE(click.clicks, 0)::int AS clicks,
+              COALESCE(conv.conversions, 0)::int AS conversions,
+              CASE WHEN COALESCE(click.clicks, 0) > 0
+                   THEN COALESCE(conv.conversions, 0)::float / click.clicks
+                   ELSE 0 END AS conversion_rate
+         FROM click_agg click
+         FULL OUTER JOIN conv_agg conv ON click.code_u = conv.code_u
+         ORDER BY clicks DESC, conversions DESC`,
+      [sellerPubkey, sinceDays]
+    );
+    return r.rows as AffiliateClickAggregate[];
+  } finally {
+    client.release();
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Email-preference + Stripe-account-state helpers
+// ---------------------------------------------------------------------------
+
+/** Disable transactional payout/pause emails for a single affiliate. */
+export async function setAffiliateEmailNotifications(
+  inviteToken: string,
+  enabled: boolean
+): Promise<Affiliate | null> {
+  const pool = getDbPool();
+  const client = await pool.connect();
+  try {
+    const r = await client.query(
+      `UPDATE affiliates
+          SET email_notifications_enabled = $2,
+              updated_at = CURRENT_TIMESTAMP
+        WHERE invite_token = $1
+        RETURNING *`,
+      [inviteToken, enabled]
+    );
+    return (r.rows[0] as Affiliate | undefined) ?? null;
+  } finally {
+    client.release();
+  }
+}
+
+/**
+ * Sync the cached Stripe-Connect onboarding flags after we receive
+ * `account.updated`. Returns the affiliate id we matched (or null).
+ */
+export async function syncAffiliateStripeAccountState(params: {
+  stripeAccountId: string;
+  chargesEnabled: boolean;
+  payoutsEnabled: boolean;
+  detailsSubmitted: boolean;
+}): Promise<number | null> {
+  const pool = getDbPool();
+  const client = await pool.connect();
+  try {
+    const r = await client.query(
+      `UPDATE affiliates
+          SET stripe_charges_enabled = $2,
+              stripe_payouts_enabled = $3,
+              stripe_onboarding_complete = $4,
+              updated_at = CURRENT_TIMESTAMP
+        WHERE stripe_account_id = $1
+        RETURNING id`,
+      [
+        params.stripeAccountId,
+        params.chargesEnabled,
+        params.payoutsEnabled,
+        params.detailsSubmitted &&
+          params.chargesEnabled &&
+          params.payoutsEnabled,
+      ]
+    );
+    return (r.rows[0]?.id as number | undefined) ?? null;
+  } finally {
+    client.release();
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Reporting helpers (year-to-date totals, per-token balances)
+// ---------------------------------------------------------------------------
+
+export interface YtdPayoutTotal {
+  affiliate_id: number;
+  affiliate_name: string;
+  email: string | null;
+  currency: string;
+  total_smallest: string;
+  payout_count: number;
+}
+
+/**
+ * Year-to-date paid-out totals per affiliate per currency, scoped to a single
+ * seller. Useful for US 1099-MISC reporting (the seller is responsible for
+ * issuing forms once an affiliate crosses the IRS threshold).
+ */
+export async function getYearToDatePayouts(
+  sellerPubkey: string,
+  year: number
+): Promise<YtdPayoutTotal[]> {
+  const pool = getDbPool();
+  const client = await pool.connect();
+  try {
+    const r = await client.query(
+      `SELECT p.affiliate_id,
+              a.name AS affiliate_name,
+              a.email AS email,
+              p.currency,
+              COALESCE(SUM(p.amount_smallest), 0)::text AS total_smallest,
+              COUNT(*)::int AS payout_count
+         FROM affiliate_payouts p
+         JOIN affiliates a ON a.id = p.affiliate_id
+         WHERE p.seller_pubkey = $1
+           AND p.status = 'paid'
+           AND EXTRACT(YEAR FROM p.paid_at) = $2
+         GROUP BY p.affiliate_id, a.name, a.email, p.currency
+         ORDER BY a.name, p.currency`,
+      [sellerPubkey, year]
+    );
+    return r.rows as YtdPayoutTotal[];
+  } finally {
+    client.release();
+  }
+}
+
+export interface AffiliateSelfBalance {
+  currency: string;
+  pending_smallest: string;
+  payable_smallest: string;
+  paid_smallest: string;
+}
+
+/**
+ * Per-currency balances for a single affiliate, looked up by their invite
+ * token (used by the affiliate's own self-service dashboard so they don't
+ * need a Nostr signature to view their own numbers).
+ */
+export async function getAffiliateBalancesByToken(
+  inviteToken: string
+): Promise<{ affiliate: Affiliate; balances: AffiliateSelfBalance[] } | null> {
+  const pool = getDbPool();
+  const client = await pool.connect();
+  try {
+    const a = await client.query(
+      `SELECT * FROM affiliates WHERE invite_token = $1`,
+      [inviteToken]
+    );
+    const affiliate = a.rows[0] as Affiliate | undefined;
+    if (!affiliate) return null;
+    const b = await client.query(
+      `SELECT currency,
+              COALESCE(SUM(CASE WHEN status = 'pending' THEN rebate_smallest ELSE 0 END), 0)::text AS pending_smallest,
+              COALESCE(SUM(CASE WHEN status = 'payable' THEN rebate_smallest ELSE 0 END), 0)::text AS payable_smallest,
+              COALESCE(SUM(CASE WHEN status = 'paid' THEN rebate_smallest ELSE 0 END), 0)::text AS paid_smallest
+         FROM affiliate_referrals
+         WHERE affiliate_id = $1
+         GROUP BY currency
+         ORDER BY currency`,
+      [affiliate.id]
+    );
+    return { affiliate, balances: b.rows as AffiliateSelfBalance[] };
+  } finally {
+    client.release();
+  }
+}
+
+/**
+ * Recent payouts for a single affiliate (by id), used by the affiliate
+ * self-service dashboard.
+ */
+export async function listRecentPayoutsForAffiliate(
+  affiliateId: number,
+  limit = 50
+): Promise<
+  Array<{
+    id: number;
+    method: PayoutMethod;
+    amount_smallest: string;
+    currency: string;
+    status: string;
+    paid_at: Date;
+    external_ref: string | null;
+  }>
+> {
+  const pool = getDbPool();
+  const client = await pool.connect();
+  try {
+    const r = await client.query(
+      `SELECT id, method, amount_smallest, currency, status, paid_at, external_ref
+         FROM affiliate_payouts
+         WHERE affiliate_id = $1
+         ORDER BY paid_at DESC
+         LIMIT $2`,
+      [affiliateId, limit]
+    );
+    return r.rows;
   } finally {
     client.release();
   }

--- a/utils/db/affiliates.ts
+++ b/utils/db/affiliates.ts
@@ -1232,6 +1232,35 @@ export async function setAffiliateEmailNotifications(
 }
 
 /**
+ * Clear cached Stripe-Connect state after `account.application.deauthorized`.
+ * The connected account is no longer transferable, so we flip every stripe_*
+ * flag to false. The `stripe_account_id` is intentionally retained for audit;
+ * process-payouts already short-circuits when stripe_payouts_enabled=false.
+ * Returns the affiliate id we matched (or null when no row owns this account).
+ */
+export async function markAffiliateStripeDeauthorized(
+  stripeAccountId: string
+): Promise<number | null> {
+  const pool = getDbPool();
+  const client = await pool.connect();
+  try {
+    const r = await client.query(
+      `UPDATE affiliates
+          SET stripe_charges_enabled = FALSE,
+              stripe_payouts_enabled = FALSE,
+              stripe_onboarding_complete = FALSE,
+              updated_at = CURRENT_TIMESTAMP
+        WHERE stripe_account_id = $1
+        RETURNING id`,
+      [stripeAccountId]
+    );
+    return (r.rows[0]?.id as number | undefined) ?? null;
+  } finally {
+    client.release();
+  }
+}
+
+/**
  * Sync the cached Stripe-Connect onboarding flags after we receive
  * `account.updated`. Returns the affiliate id we matched (or null).
  */

--- a/utils/db/affiliates.ts
+++ b/utils/db/affiliates.ts
@@ -1,0 +1,763 @@
+import { randomBytes } from "crypto";
+import { getDbPool } from "@/utils/db/db-service";
+
+export type RebateType = "percent" | "fixed";
+export type DiscountType = "percent" | "fixed";
+export type PayoutSchedule = "every_sale" | "daily" | "weekly" | "monthly";
+export type ReferralStatus = "pending" | "payable" | "paid" | "cancelled";
+export type PaymentRail = "stripe" | "bitcoin";
+export type PayoutMethod = "stripe" | "lightning" | "manual";
+
+export interface Affiliate {
+  id: number;
+  seller_pubkey: string;
+  name: string;
+  email: string | null;
+  affiliate_pubkey: string | null;
+  invite_token: string;
+  invite_claimed_at: Date | null;
+  lightning_address: string | null;
+  stripe_account_id: string | null;
+  notes: string | null;
+  created_at: Date;
+  updated_at: Date;
+}
+
+export interface AffiliateCode {
+  id: number;
+  affiliate_id: number;
+  seller_pubkey: string;
+  code: string;
+  rebate_type: RebateType;
+  rebate_value: number;
+  buyer_discount_type: DiscountType;
+  buyer_discount_value: number;
+  currency: string | null;
+  payout_schedule: PayoutSchedule;
+  expiration: number | null;
+  max_uses: number | null;
+  times_used: number;
+  is_active: boolean;
+  created_at: Date;
+  updated_at: Date;
+}
+
+export interface AffiliateReferral {
+  id: number;
+  affiliate_id: number;
+  code_id: number;
+  seller_pubkey: string;
+  order_id: string;
+  payment_rail: PaymentRail;
+  gross_subtotal_smallest: string;
+  buyer_discount_smallest: string;
+  rebate_smallest: string;
+  currency: string;
+  status: ReferralStatus;
+  payout_id: number | null;
+  realtime_transfer_ref: string | null;
+  created_at: Date;
+  updated_at: Date;
+}
+
+function generateInviteToken(): string {
+  return randomBytes(24).toString("base64url");
+}
+
+// ---------------------------------------------------------------------------
+// Affiliates
+// ---------------------------------------------------------------------------
+
+export async function createAffiliate(params: {
+  sellerPubkey: string;
+  name: string;
+  email?: string | null;
+  lightningAddress?: string | null;
+  stripeAccountId?: string | null;
+  notes?: string | null;
+}): Promise<Affiliate> {
+  const pool = getDbPool();
+  const client = await pool.connect();
+  try {
+    const result = await client.query(
+      `INSERT INTO affiliates
+         (seller_pubkey, name, email, lightning_address, stripe_account_id, notes, invite_token)
+       VALUES ($1, $2, $3, $4, $5, $6, $7)
+       RETURNING *`,
+      [
+        params.sellerPubkey,
+        params.name,
+        params.email ?? null,
+        params.lightningAddress ?? null,
+        params.stripeAccountId ?? null,
+        params.notes ?? null,
+        generateInviteToken(),
+      ]
+    );
+    return result.rows[0] as Affiliate;
+  } finally {
+    client.release();
+  }
+}
+
+export async function listAffiliatesBySeller(
+  sellerPubkey: string
+): Promise<Affiliate[]> {
+  const pool = getDbPool();
+  const client = await pool.connect();
+  try {
+    const result = await client.query(
+      `SELECT * FROM affiliates WHERE seller_pubkey = $1 ORDER BY created_at DESC`,
+      [sellerPubkey]
+    );
+    return result.rows as Affiliate[];
+  } finally {
+    client.release();
+  }
+}
+
+export async function getAffiliateById(id: number): Promise<Affiliate | null> {
+  const pool = getDbPool();
+  const client = await pool.connect();
+  try {
+    const result = await client.query(
+      `SELECT * FROM affiliates WHERE id = $1`,
+      [id]
+    );
+    return (result.rows[0] as Affiliate) ?? null;
+  } finally {
+    client.release();
+  }
+}
+
+export async function getAffiliateByInviteToken(
+  token: string
+): Promise<Affiliate | null> {
+  const pool = getDbPool();
+  const client = await pool.connect();
+  try {
+    const result = await client.query(
+      `SELECT * FROM affiliates WHERE invite_token = $1`,
+      [token]
+    );
+    return (result.rows[0] as Affiliate) ?? null;
+  } finally {
+    client.release();
+  }
+}
+
+export async function updateAffiliate(
+  id: number,
+  sellerPubkey: string,
+  patch: Partial<{
+    name: string;
+    email: string | null;
+    lightningAddress: string | null;
+    stripeAccountId: string | null;
+    notes: string | null;
+  }>
+): Promise<Affiliate | null> {
+  const pool = getDbPool();
+  const client = await pool.connect();
+  try {
+    const fields: string[] = [];
+    const values: unknown[] = [];
+    let i = 1;
+    if (patch.name !== undefined) {
+      fields.push(`name = $${i++}`);
+      values.push(patch.name);
+    }
+    if (patch.email !== undefined) {
+      fields.push(`email = $${i++}`);
+      values.push(patch.email);
+    }
+    if (patch.lightningAddress !== undefined) {
+      fields.push(`lightning_address = $${i++}`);
+      values.push(patch.lightningAddress);
+    }
+    if (patch.stripeAccountId !== undefined) {
+      fields.push(`stripe_account_id = $${i++}`);
+      values.push(patch.stripeAccountId);
+    }
+    if (patch.notes !== undefined) {
+      fields.push(`notes = $${i++}`);
+      values.push(patch.notes);
+    }
+    if (fields.length === 0) return getAffiliateById(id);
+    fields.push(`updated_at = CURRENT_TIMESTAMP`);
+    values.push(id, sellerPubkey);
+    const result = await client.query(
+      `UPDATE affiliates SET ${fields.join(", ")}
+         WHERE id = $${i++} AND seller_pubkey = $${i++}
+         RETURNING *`,
+      values
+    );
+    return (result.rows[0] as Affiliate) ?? null;
+  } finally {
+    client.release();
+  }
+}
+
+export async function updateAffiliatePayoutMethod(
+  inviteToken: string,
+  patch: {
+    affiliatePubkey?: string | null;
+    lightningAddress?: string | null;
+    stripeAccountId?: string | null;
+  }
+): Promise<Affiliate | null> {
+  const pool = getDbPool();
+  const client = await pool.connect();
+  try {
+    const fields: string[] = [];
+    const values: unknown[] = [];
+    let i = 1;
+    if (patch.affiliatePubkey !== undefined) {
+      fields.push(`affiliate_pubkey = $${i++}`);
+      values.push(patch.affiliatePubkey);
+    }
+    if (patch.lightningAddress !== undefined) {
+      fields.push(`lightning_address = $${i++}`);
+      values.push(patch.lightningAddress);
+    }
+    if (patch.stripeAccountId !== undefined) {
+      fields.push(`stripe_account_id = $${i++}`);
+      values.push(patch.stripeAccountId);
+    }
+    fields.push(
+      `invite_claimed_at = COALESCE(invite_claimed_at, CURRENT_TIMESTAMP)`
+    );
+    fields.push(`updated_at = CURRENT_TIMESTAMP`);
+    values.push(inviteToken);
+    const result = await client.query(
+      `UPDATE affiliates SET ${fields.join(", ")}
+         WHERE invite_token = $${i++}
+         RETURNING *`,
+      values
+    );
+    return (result.rows[0] as Affiliate) ?? null;
+  } finally {
+    client.release();
+  }
+}
+
+export async function deleteAffiliate(
+  id: number,
+  sellerPubkey: string
+): Promise<void> {
+  const pool = getDbPool();
+  const client = await pool.connect();
+  try {
+    await client.query(
+      `DELETE FROM affiliates WHERE id = $1 AND seller_pubkey = $2`,
+      [id, sellerPubkey]
+    );
+  } finally {
+    client.release();
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Affiliate codes
+// ---------------------------------------------------------------------------
+
+export async function createAffiliateCode(params: {
+  affiliateId: number;
+  sellerPubkey: string;
+  code: string;
+  rebateType: RebateType;
+  rebateValue: number;
+  buyerDiscountType: DiscountType;
+  buyerDiscountValue: number;
+  currency?: string | null;
+  payoutSchedule: PayoutSchedule;
+  expiration?: number | null;
+  maxUses?: number | null;
+}): Promise<AffiliateCode> {
+  const pool = getDbPool();
+  const client = await pool.connect();
+  try {
+    const result = await client.query(
+      `INSERT INTO affiliate_codes
+         (affiliate_id, seller_pubkey, code, rebate_type, rebate_value,
+          buyer_discount_type, buyer_discount_value, currency,
+          payout_schedule, expiration, max_uses)
+       VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11)
+       RETURNING *`,
+      [
+        params.affiliateId,
+        params.sellerPubkey,
+        params.code,
+        params.rebateType,
+        params.rebateValue,
+        params.buyerDiscountType,
+        params.buyerDiscountValue,
+        params.currency ?? null,
+        params.payoutSchedule,
+        params.expiration ?? null,
+        params.maxUses ?? null,
+      ]
+    );
+    return result.rows[0] as AffiliateCode;
+  } finally {
+    client.release();
+  }
+}
+
+export async function listAffiliateCodesBySeller(
+  sellerPubkey: string
+): Promise<(AffiliateCode & { affiliate_name: string })[]> {
+  const pool = getDbPool();
+  const client = await pool.connect();
+  try {
+    const result = await client.query(
+      `SELECT c.*, a.name AS affiliate_name
+         FROM affiliate_codes c
+         JOIN affiliates a ON a.id = c.affiliate_id
+         WHERE c.seller_pubkey = $1
+         ORDER BY c.created_at DESC`,
+      [sellerPubkey]
+    );
+    return result.rows;
+  } finally {
+    client.release();
+  }
+}
+
+export async function listAffiliateCodesByAffiliate(
+  affiliateId: number
+): Promise<AffiliateCode[]> {
+  const pool = getDbPool();
+  const client = await pool.connect();
+  try {
+    const result = await client.query(
+      `SELECT * FROM affiliate_codes WHERE affiliate_id = $1 ORDER BY created_at DESC`,
+      [affiliateId]
+    );
+    return result.rows as AffiliateCode[];
+  } finally {
+    client.release();
+  }
+}
+
+export async function updateAffiliateCode(
+  id: number,
+  sellerPubkey: string,
+  patch: Partial<{
+    rebateType: RebateType;
+    rebateValue: number;
+    buyerDiscountType: DiscountType;
+    buyerDiscountValue: number;
+    currency: string | null;
+    payoutSchedule: PayoutSchedule;
+    expiration: number | null;
+    maxUses: number | null;
+    isActive: boolean;
+  }>
+): Promise<AffiliateCode | null> {
+  const pool = getDbPool();
+  const client = await pool.connect();
+  try {
+    const fields: string[] = [];
+    const values: unknown[] = [];
+    let i = 1;
+    const map: Array<[string, keyof typeof patch]> = [
+      ["rebate_type", "rebateType"],
+      ["rebate_value", "rebateValue"],
+      ["buyer_discount_type", "buyerDiscountType"],
+      ["buyer_discount_value", "buyerDiscountValue"],
+      ["currency", "currency"],
+      ["payout_schedule", "payoutSchedule"],
+      ["expiration", "expiration"],
+      ["max_uses", "maxUses"],
+      ["is_active", "isActive"],
+    ];
+    for (const [col, key] of map) {
+      const v = patch[key];
+      if (v !== undefined) {
+        fields.push(`${col} = $${i++}`);
+        values.push(v);
+      }
+    }
+    if (fields.length === 0) {
+      const r = await client.query(
+        `SELECT * FROM affiliate_codes WHERE id = $1 AND seller_pubkey = $2`,
+        [id, sellerPubkey]
+      );
+      return (r.rows[0] as AffiliateCode) ?? null;
+    }
+    fields.push(`updated_at = CURRENT_TIMESTAMP`);
+    values.push(id, sellerPubkey);
+    const result = await client.query(
+      `UPDATE affiliate_codes SET ${fields.join(", ")}
+         WHERE id = $${i++} AND seller_pubkey = $${i++}
+         RETURNING *`,
+      values
+    );
+    return (result.rows[0] as AffiliateCode) ?? null;
+  } finally {
+    client.release();
+  }
+}
+
+export async function deleteAffiliateCode(
+  id: number,
+  sellerPubkey: string
+): Promise<void> {
+  const pool = getDbPool();
+  const client = await pool.connect();
+  try {
+    await client.query(
+      `DELETE FROM affiliate_codes WHERE id = $1 AND seller_pubkey = $2`,
+      [id, sellerPubkey]
+    );
+  } finally {
+    client.release();
+  }
+}
+
+export async function lookupAffiliateCode(
+  sellerPubkey: string,
+  code: string
+): Promise<(AffiliateCode & { affiliate: Affiliate }) | null> {
+  const pool = getDbPool();
+  const client = await pool.connect();
+  try {
+    const result = await client.query(
+      `SELECT c.*, row_to_json(a.*) AS affiliate
+         FROM affiliate_codes c
+         JOIN affiliates a ON a.id = c.affiliate_id
+         WHERE c.seller_pubkey = $1 AND UPPER(c.code) = UPPER($2)`,
+      [sellerPubkey, code]
+    );
+    if (result.rows.length === 0) return null;
+    return result.rows[0];
+  } finally {
+    client.release();
+  }
+}
+
+export async function isAffiliateCodeValid(c: AffiliateCode): Promise<boolean> {
+  if (!c.is_active) return false;
+  if (c.expiration && Date.now() / 1000 > c.expiration) return false;
+  if (c.max_uses !== null && c.times_used >= c.max_uses) return false;
+  return true;
+}
+
+export async function incrementAffiliateCodeUsage(
+  codeId: number
+): Promise<void> {
+  const pool = getDbPool();
+  const client = await pool.connect();
+  try {
+    await client.query(
+      `UPDATE affiliate_codes SET times_used = times_used + 1, updated_at = CURRENT_TIMESTAMP WHERE id = $1`,
+      [codeId]
+    );
+  } finally {
+    client.release();
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Discount + rebate math (works in smallest units, "cents" or sats)
+// ---------------------------------------------------------------------------
+
+/**
+ * Compute the buyer discount in smallest units. Caps the discount strictly
+ * below the gross so the buyer never pays zero / negative.
+ */
+export function computeBuyerDiscountSmallest(
+  grossSmallest: number,
+  type: DiscountType,
+  value: number
+): number {
+  if (!Number.isFinite(grossSmallest) || grossSmallest <= 0) return 0;
+  if (!Number.isFinite(value) || value <= 0) return 0;
+  let cut = 0;
+  if (type === "percent") {
+    cut = Math.floor((grossSmallest * Math.min(value, 100)) / 100);
+  } else {
+    // Fixed values are stored in major units (e.g. dollars); convert to cents.
+    cut = Math.floor(value * 100);
+  }
+  if (cut >= grossSmallest) return grossSmallest - 1;
+  return Math.max(cut, 0);
+}
+
+/**
+ * Compute the affiliate rebate in smallest units, applied to the *net*
+ * subtotal (after the buyer discount) so the rebate scales with what the
+ * seller actually receives.
+ */
+export function computeRebateSmallest(
+  netSmallest: number,
+  type: RebateType,
+  value: number
+): number {
+  if (!Number.isFinite(netSmallest) || netSmallest <= 0) return 0;
+  if (!Number.isFinite(value) || value <= 0) return 0;
+  let cut = 0;
+  if (type === "percent") {
+    cut = Math.floor((netSmallest * Math.min(value, 100)) / 100);
+  } else {
+    cut = Math.floor(value * 100);
+  }
+  if (cut >= netSmallest) return netSmallest;
+  return Math.max(cut, 0);
+}
+
+// ---------------------------------------------------------------------------
+// Referrals
+// ---------------------------------------------------------------------------
+
+export async function recordReferral(params: {
+  affiliateId: number;
+  codeId: number;
+  sellerPubkey: string;
+  orderId: string;
+  paymentRail: PaymentRail;
+  grossSubtotalSmallest: number;
+  buyerDiscountSmallest: number;
+  rebateSmallest: number;
+  currency: string;
+  initialStatus?: ReferralStatus;
+  realtimeTransferRef?: string | null;
+}): Promise<AffiliateReferral> {
+  const pool = getDbPool();
+  const client = await pool.connect();
+  try {
+    const result = await client.query(
+      `INSERT INTO affiliate_referrals
+         (affiliate_id, code_id, seller_pubkey, order_id, payment_rail,
+          gross_subtotal_smallest, buyer_discount_smallest, rebate_smallest,
+          currency, status, realtime_transfer_ref)
+       VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11)
+       ON CONFLICT (order_id, code_id) DO UPDATE SET
+         status = EXCLUDED.status,
+         realtime_transfer_ref = COALESCE(EXCLUDED.realtime_transfer_ref, affiliate_referrals.realtime_transfer_ref),
+         updated_at = CURRENT_TIMESTAMP
+       RETURNING *`,
+      [
+        params.affiliateId,
+        params.codeId,
+        params.sellerPubkey,
+        params.orderId,
+        params.paymentRail,
+        params.grossSubtotalSmallest,
+        params.buyerDiscountSmallest,
+        params.rebateSmallest,
+        params.currency,
+        params.initialStatus ?? "pending",
+        params.realtimeTransferRef ?? null,
+      ]
+    );
+    return result.rows[0] as AffiliateReferral;
+  } finally {
+    client.release();
+  }
+}
+
+export async function listReferralsBySeller(
+  sellerPubkey: string,
+  status?: ReferralStatus
+): Promise<AffiliateReferral[]> {
+  const pool = getDbPool();
+  const client = await pool.connect();
+  try {
+    if (status) {
+      const r = await client.query(
+        `SELECT * FROM affiliate_referrals WHERE seller_pubkey = $1 AND status = $2 ORDER BY created_at DESC`,
+        [sellerPubkey, status]
+      );
+      return r.rows as AffiliateReferral[];
+    }
+    const r = await client.query(
+      `SELECT * FROM affiliate_referrals WHERE seller_pubkey = $1 ORDER BY created_at DESC`,
+      [sellerPubkey]
+    );
+    return r.rows as AffiliateReferral[];
+  } finally {
+    client.release();
+  }
+}
+
+export interface AffiliateBalance {
+  affiliate_id: number;
+  affiliate_name: string;
+  currency: string;
+  pending_smallest: string; // pending or payable
+  payable_smallest: string;
+  paid_smallest: string;
+  referral_count: number;
+}
+
+export async function getAffiliateBalances(
+  sellerPubkey: string
+): Promise<AffiliateBalance[]> {
+  const pool = getDbPool();
+  const client = await pool.connect();
+  try {
+    const r = await client.query(
+      `SELECT
+         r.affiliate_id,
+         a.name AS affiliate_name,
+         r.currency,
+         COALESCE(SUM(CASE WHEN r.status IN ('pending','payable') THEN r.rebate_smallest ELSE 0 END), 0) AS pending_smallest,
+         COALESCE(SUM(CASE WHEN r.status = 'payable' THEN r.rebate_smallest ELSE 0 END), 0) AS payable_smallest,
+         COALESCE(SUM(CASE WHEN r.status = 'paid' THEN r.rebate_smallest ELSE 0 END), 0) AS paid_smallest,
+         COUNT(*)::int AS referral_count
+       FROM affiliate_referrals r
+       JOIN affiliates a ON a.id = r.affiliate_id
+       WHERE r.seller_pubkey = $1
+       GROUP BY r.affiliate_id, a.name, r.currency
+       ORDER BY a.name`,
+      [sellerPubkey]
+    );
+    return r.rows as AffiliateBalance[];
+  } finally {
+    client.release();
+  }
+}
+
+/**
+ * Move all eligible referrals for an affiliate (matching schedule + currency)
+ * to status='payable' so the scheduler picks them up.
+ */
+export async function markReferralsPayableBySchedule(
+  schedule: PayoutSchedule
+): Promise<number> {
+  const pool = getDbPool();
+  const client = await pool.connect();
+  try {
+    const r = await client.query(
+      `UPDATE affiliate_referrals AS r
+         SET status = 'payable', updated_at = CURRENT_TIMESTAMP
+       FROM affiliate_codes c
+       WHERE r.code_id = c.id
+         AND c.payout_schedule = $1
+         AND r.status = 'pending'`,
+      [schedule]
+    );
+    return r.rowCount ?? 0;
+  } finally {
+    client.release();
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Payouts
+// ---------------------------------------------------------------------------
+
+export async function createPayoutAndSettle(params: {
+  affiliateId: number;
+  sellerPubkey: string;
+  method: PayoutMethod;
+  amountSmallest: number;
+  currency: string;
+  externalRef?: string | null;
+  note?: string | null;
+  referralIds: number[];
+  status?: "paid" | "failed";
+}): Promise<{ payoutId: number }> {
+  const pool = getDbPool();
+  const client = await pool.connect();
+  try {
+    await client.query("BEGIN");
+    const insert = await client.query(
+      `INSERT INTO affiliate_payouts
+         (affiliate_id, seller_pubkey, method, amount_smallest, currency, external_ref, note, status)
+       VALUES ($1,$2,$3,$4,$5,$6,$7,$8)
+       RETURNING id`,
+      [
+        params.affiliateId,
+        params.sellerPubkey,
+        params.method,
+        params.amountSmallest,
+        params.currency,
+        params.externalRef ?? null,
+        params.note ?? null,
+        params.status ?? "paid",
+      ]
+    );
+    const payoutId = insert.rows[0].id as number;
+    if (params.referralIds.length > 0 && (params.status ?? "paid") === "paid") {
+      await client.query(
+        `UPDATE affiliate_referrals
+           SET status = 'paid', payout_id = $1, updated_at = CURRENT_TIMESTAMP
+           WHERE id = ANY($2::int[])`,
+        [payoutId, params.referralIds]
+      );
+    }
+    await client.query("COMMIT");
+    return { payoutId };
+  } catch (err) {
+    await client.query("ROLLBACK");
+    throw err;
+  } finally {
+    client.release();
+  }
+}
+
+export async function listPayoutsBySeller(sellerPubkey: string): Promise<
+  Array<{
+    id: number;
+    affiliate_id: number;
+    affiliate_name: string;
+    method: PayoutMethod;
+    amount_smallest: string;
+    currency: string;
+    external_ref: string | null;
+    note: string | null;
+    status: string;
+    paid_at: Date;
+  }>
+> {
+  const pool = getDbPool();
+  const client = await pool.connect();
+  try {
+    const r = await client.query(
+      `SELECT p.id, p.affiliate_id, a.name AS affiliate_name, p.method,
+              p.amount_smallest, p.currency, p.external_ref, p.note,
+              p.status, p.paid_at
+         FROM affiliate_payouts p
+         JOIN affiliates a ON a.id = p.affiliate_id
+         WHERE p.seller_pubkey = $1
+         ORDER BY p.paid_at DESC
+         LIMIT 200`,
+      [sellerPubkey]
+    );
+    return r.rows;
+  } finally {
+    client.release();
+  }
+}
+
+/**
+ * Aggregate all payable referrals for a single (affiliate, currency) pair.
+ */
+export async function getPayableReferralBundle(affiliateId: number): Promise<
+  Array<{
+    currency: string;
+    total_smallest: string;
+    referral_ids: number[];
+    seller_pubkey: string;
+  }>
+> {
+  const pool = getDbPool();
+  const client = await pool.connect();
+  try {
+    const r = await client.query(
+      `SELECT currency, seller_pubkey,
+              COALESCE(SUM(rebate_smallest), 0)::text AS total_smallest,
+              array_agg(id) AS referral_ids
+         FROM affiliate_referrals
+         WHERE affiliate_id = $1 AND status = 'payable'
+         GROUP BY currency, seller_pubkey`,
+      [affiliateId]
+    );
+    return r.rows;
+  } finally {
+    client.release();
+  }
+}

--- a/utils/db/db-service.ts
+++ b/utils/db/db-service.ts
@@ -872,6 +872,75 @@ async function initializeTables(): Promise<void> {
       CREATE INDEX IF NOT EXISTS idx_affiliate_payouts_seller_pubkey ON affiliate_payouts(seller_pubkey);
     `);
 
+    // -----------------------------------------------------------------
+    // Idempotent affiliate-program migrations. This block mirrors the
+    // DO $aff_migrate$ block in db/schema.sql so that environments which
+    // bootstrap from this code path (rather than running schema.sql
+    // directly) stay in sync.  Safe to re-run.
+    // -----------------------------------------------------------------
+    await client.query(`
+      DO $aff_migrate_inline$
+      BEGIN
+        EXECUTE 'UPDATE affiliate_codes SET payout_schedule = ''monthly'' WHERE payout_schedule IN (''every_sale'', ''daily'')';
+        IF EXISTS (
+          SELECT 1 FROM pg_constraint WHERE conname = 'affiliate_codes_payout_schedule_check'
+        ) THEN
+          ALTER TABLE affiliate_codes DROP CONSTRAINT affiliate_codes_payout_schedule_check;
+        END IF;
+        ALTER TABLE affiliate_codes
+          ADD CONSTRAINT affiliate_codes_payout_schedule_check
+          CHECK (payout_schedule IN ('weekly', 'biweekly', 'monthly'));
+        ALTER TABLE affiliate_codes ALTER COLUMN payout_schedule SET DEFAULT 'monthly';
+
+        ALTER TABLE affiliate_referrals
+          ADD COLUMN IF NOT EXISTS refunded_smallest NUMERIC(20,0) NOT NULL DEFAULT 0;
+        ALTER TABLE affiliate_referrals
+          ADD COLUMN IF NOT EXISTS refund_event_ref TEXT;
+        IF EXISTS (
+          SELECT 1 FROM pg_constraint WHERE conname = 'affiliate_referrals_status_check'
+        ) THEN
+          ALTER TABLE affiliate_referrals DROP CONSTRAINT affiliate_referrals_status_check;
+        END IF;
+        ALTER TABLE affiliate_referrals
+          ADD CONSTRAINT affiliate_referrals_status_check
+          CHECK (status IN ('pending', 'payable', 'paid', 'cancelled', 'refunded'));
+
+        ALTER TABLE affiliates
+          ADD COLUMN IF NOT EXISTS payouts_enabled BOOLEAN NOT NULL DEFAULT TRUE;
+        ALTER TABLE affiliates
+          ADD COLUMN IF NOT EXISTS payout_failure_count INTEGER NOT NULL DEFAULT 0;
+        ALTER TABLE affiliates
+          ADD COLUMN IF NOT EXISTS last_payout_failure_at TIMESTAMP;
+        ALTER TABLE affiliates
+          ADD COLUMN IF NOT EXISTS last_payout_failure_reason TEXT;
+        ALTER TABLE affiliates
+          ADD COLUMN IF NOT EXISTS email_notifications_enabled BOOLEAN NOT NULL DEFAULT TRUE;
+        ALTER TABLE affiliates
+          ADD COLUMN IF NOT EXISTS stripe_charges_enabled BOOLEAN NOT NULL DEFAULT FALSE;
+        ALTER TABLE affiliates
+          ADD COLUMN IF NOT EXISTS stripe_payouts_enabled BOOLEAN NOT NULL DEFAULT FALSE;
+        ALTER TABLE affiliates
+          ADD COLUMN IF NOT EXISTS stripe_onboarding_complete BOOLEAN NOT NULL DEFAULT FALSE;
+
+        CREATE UNIQUE INDEX IF NOT EXISTS uniq_affiliate_codes_seller_upper_code
+          ON affiliate_codes (seller_pubkey, UPPER(code));
+
+        CREATE TABLE IF NOT EXISTS affiliate_clicks (
+            id BIGSERIAL PRIMARY KEY,
+            seller_pubkey TEXT NOT NULL,
+            code TEXT NOT NULL,
+            landing_path TEXT,
+            referer_host TEXT,
+            created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+        );
+        CREATE INDEX IF NOT EXISTS idx_affiliate_clicks_seller_code
+          ON affiliate_clicks(seller_pubkey, code);
+        CREATE INDEX IF NOT EXISTS idx_affiliate_clicks_created_at
+          ON affiliate_clicks(created_at);
+      END
+      $aff_migrate_inline$;
+    `);
+
     tablesInitialized = true;
     initializingTables = false;
   } catch (error) {

--- a/utils/db/db-service.ts
+++ b/utils/db/db-service.ts
@@ -789,6 +789,87 @@ async function initializeTables(): Promise<void> {
       );
       CREATE INDEX IF NOT EXISTS idx_inventory_log_product_id ON inventory_log(product_id);
       CREATE INDEX IF NOT EXISTS idx_inventory_log_order_id ON inventory_log(order_id);
+
+      -- Affiliate program tables (mirrors db/schema.sql).
+      CREATE TABLE IF NOT EXISTS affiliates (
+        id SERIAL PRIMARY KEY,
+        seller_pubkey TEXT NOT NULL,
+        name TEXT NOT NULL,
+        email TEXT,
+        affiliate_pubkey TEXT,
+        invite_token TEXT NOT NULL UNIQUE,
+        invite_claimed_at TIMESTAMP,
+        lightning_address TEXT,
+        stripe_account_id TEXT,
+        notes TEXT,
+        created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+        updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+      );
+      CREATE INDEX IF NOT EXISTS idx_affiliates_seller_pubkey ON affiliates(seller_pubkey);
+      CREATE INDEX IF NOT EXISTS idx_affiliates_invite_token ON affiliates(invite_token);
+      CREATE INDEX IF NOT EXISTS idx_affiliates_affiliate_pubkey ON affiliates(affiliate_pubkey);
+
+      CREATE TABLE IF NOT EXISTS affiliate_codes (
+        id SERIAL PRIMARY KEY,
+        affiliate_id INTEGER NOT NULL REFERENCES affiliates(id) ON DELETE CASCADE,
+        seller_pubkey TEXT NOT NULL,
+        code TEXT NOT NULL,
+        rebate_type TEXT NOT NULL CHECK (rebate_type IN ('percent', 'fixed')),
+        rebate_value NUMERIC(12,2) NOT NULL CHECK (rebate_value >= 0),
+        buyer_discount_type TEXT NOT NULL DEFAULT 'percent' CHECK (buyer_discount_type IN ('percent', 'fixed')),
+        buyer_discount_value NUMERIC(12,2) NOT NULL DEFAULT 0 CHECK (buyer_discount_value >= 0),
+        currency TEXT,
+        payout_schedule TEXT NOT NULL DEFAULT 'every_sale' CHECK (payout_schedule IN ('every_sale', 'daily', 'weekly', 'monthly')),
+        expiration BIGINT,
+        max_uses INTEGER,
+        times_used INTEGER NOT NULL DEFAULT 0,
+        is_active BOOLEAN NOT NULL DEFAULT TRUE,
+        created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+        updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+        UNIQUE(seller_pubkey, code)
+      );
+      CREATE INDEX IF NOT EXISTS idx_affiliate_codes_seller_pubkey ON affiliate_codes(seller_pubkey);
+      CREATE INDEX IF NOT EXISTS idx_affiliate_codes_affiliate_id ON affiliate_codes(affiliate_id);
+      CREATE INDEX IF NOT EXISTS idx_affiliate_codes_code ON affiliate_codes(code);
+
+      CREATE TABLE IF NOT EXISTS affiliate_referrals (
+        id SERIAL PRIMARY KEY,
+        affiliate_id INTEGER NOT NULL REFERENCES affiliates(id) ON DELETE CASCADE,
+        code_id INTEGER NOT NULL REFERENCES affiliate_codes(id) ON DELETE CASCADE,
+        seller_pubkey TEXT NOT NULL,
+        order_id TEXT NOT NULL,
+        payment_rail TEXT NOT NULL CHECK (payment_rail IN ('stripe', 'bitcoin')),
+        gross_subtotal_smallest NUMERIC(20,0) NOT NULL,
+        buyer_discount_smallest NUMERIC(20,0) NOT NULL DEFAULT 0,
+        rebate_smallest NUMERIC(20,0) NOT NULL DEFAULT 0,
+        currency TEXT NOT NULL,
+        status TEXT NOT NULL DEFAULT 'pending' CHECK (status IN ('pending', 'payable', 'paid', 'cancelled')),
+        payout_id INTEGER,
+        realtime_transfer_ref TEXT,
+        created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+        updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+        UNIQUE(order_id, code_id)
+      );
+      CREATE INDEX IF NOT EXISTS idx_affiliate_referrals_affiliate_id ON affiliate_referrals(affiliate_id);
+      CREATE INDEX IF NOT EXISTS idx_affiliate_referrals_seller_pubkey ON affiliate_referrals(seller_pubkey);
+      CREATE INDEX IF NOT EXISTS idx_affiliate_referrals_status ON affiliate_referrals(status);
+      CREATE INDEX IF NOT EXISTS idx_affiliate_referrals_order_id ON affiliate_referrals(order_id);
+
+      CREATE TABLE IF NOT EXISTS affiliate_payouts (
+        id SERIAL PRIMARY KEY,
+        affiliate_id INTEGER NOT NULL REFERENCES affiliates(id) ON DELETE CASCADE,
+        seller_pubkey TEXT NOT NULL,
+        method TEXT NOT NULL CHECK (method IN ('stripe', 'lightning', 'manual')),
+        amount_smallest NUMERIC(20,0) NOT NULL,
+        currency TEXT NOT NULL,
+        external_ref TEXT,
+        note TEXT,
+        status TEXT NOT NULL DEFAULT 'paid' CHECK (status IN ('paid', 'failed')),
+        paid_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+        created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+      );
+      CREATE INDEX IF NOT EXISTS idx_affiliate_payouts_affiliate_id ON affiliate_payouts(affiliate_id);
+      CREATE INDEX IF NOT EXISTS idx_affiliate_payouts_seller_pubkey ON affiliate_payouts(seller_pubkey);
     `);
 
     tablesInitialized = true;

--- a/utils/email/email-service.ts
+++ b/utils/email/email-service.ts
@@ -13,6 +13,9 @@ import {
   paymentFailedBuyerEmail,
   paymentFailedSellerEmail,
   transferFailureAlertEmail,
+  affiliatePaidEmail,
+  affiliatePausedToAffiliateEmail,
+  affiliatePausedToSellerEmail,
   OrderEmailParams,
   SubscriptionEmailParams,
 } from "./email-templates";
@@ -21,7 +24,8 @@ export async function sendEmail(
   to: string,
   subject: string,
   html: string,
-  replyTo?: string
+  replyTo?: string,
+  headers?: Record<string, string>
 ): Promise<boolean> {
   try {
     const { client, fromEmail } = await getUncachableSendGridClient();
@@ -33,6 +37,11 @@ export async function sendEmail(
     };
     if (replyTo) {
       msg.replyTo = replyTo;
+    }
+    if (headers && Object.keys(headers).length > 0) {
+      // SendGrid honors RFC headers passed via the `headers` field. Required
+      // for List-Unsubscribe / RFC 8058 one-click compliance on Gmail/Yahoo.
+      msg.headers = headers;
     }
     await client.send(msg);
     return true;
@@ -177,6 +186,45 @@ export async function sendPaymentFailedToSeller(
   }
 ): Promise<boolean> {
   const { subject, html } = paymentFailedSellerEmail(params);
+  return sendEmail(sellerEmail, subject, html);
+}
+
+export async function sendAffiliatePaidEmail(
+  affiliateEmail: string,
+  params: {
+    affiliateName: string;
+    amountSmallest: number;
+    currency: string;
+    method: "stripe" | "lightning" | "manual";
+    externalRef?: string | null;
+    unsubscribeUrl?: string | null;
+  }
+): Promise<boolean> {
+  const { subject, html, headers } = affiliatePaidEmail(params);
+  return sendEmail(affiliateEmail, subject, html, undefined, headers);
+}
+
+export async function sendAffiliatePausedToAffiliate(
+  affiliateEmail: string,
+  params: {
+    affiliateName: string;
+    reason: string;
+    unsubscribeUrl?: string | null;
+  }
+): Promise<boolean> {
+  const { subject, html, headers } = affiliatePausedToAffiliateEmail(params);
+  return sendEmail(affiliateEmail, subject, html, undefined, headers);
+}
+
+export async function sendAffiliatePausedToSeller(
+  sellerEmail: string,
+  params: {
+    affiliateName: string;
+    reason: string;
+    failureCount: number;
+  }
+): Promise<boolean> {
+  const { subject, html } = affiliatePausedToSellerEmail(params);
   return sendEmail(sellerEmail, subject, html);
 }
 

--- a/utils/email/email-templates.ts
+++ b/utils/email/email-templates.ts
@@ -829,6 +829,127 @@ export function transferFailureAlertEmail(params: {
   };
 }
 
+// ---------------------------------------------------------------------------
+// Affiliate program emails
+// ---------------------------------------------------------------------------
+
+function formatPayoutAmount(amountSmallest: number, currency: string): string {
+  const c = currency.toLowerCase();
+  if (c === "sats") return `${amountSmallest.toLocaleString()} sats`;
+  // Treat everything else as a fiat ISO code with cents.
+  const major = (amountSmallest / 100).toFixed(2);
+  return `${major} ${currency.toUpperCase()}`;
+}
+
+function unsubscribeFooter(unsubscribeUrl?: string | null): string {
+  if (!unsubscribeUrl) return "";
+  return `
+    <p style="margin:16px 0 0;color:#9ca3af;font-size:12px;line-height:1.5;">
+      Don't want these emails?
+      <a href="${esc(unsubscribeUrl)}" style="color:#6b7280;text-decoration:underline;">Unsubscribe in one click</a>.
+    </p>`;
+}
+
+export function affiliatePaidEmail(params: {
+  affiliateName: string;
+  amountSmallest: number;
+  currency: string;
+  method: "stripe" | "lightning" | "manual";
+  externalRef?: string | null;
+  unsubscribeUrl?: string | null;
+}): { subject: string; html: string; headers?: Record<string, string> } {
+  const amount = formatPayoutAmount(params.amountSmallest, params.currency);
+  const methodLabel =
+    params.method === "stripe"
+      ? "Stripe Connect"
+      : params.method === "lightning"
+        ? "Lightning"
+        : "manual settlement";
+  const ref = params.externalRef
+    ? `<p style="margin:0 0 8px;color:#6b7280;font-size:13px;">Reference: <code>${esc(params.externalRef)}</code></p>`
+    : "";
+  const body = `
+    <h2 style="margin:0 0 16px;color:#111827;font-size:20px;font-weight:700;">You just got paid</h2>
+    <p style="margin:0 0 16px;color:#374151;font-size:15px;line-height:1.6;">
+      Hi ${esc(params.affiliateName)}, an affiliate payout of
+      <strong>${esc(amount)}</strong> was just sent to you via ${esc(methodLabel)}.
+    </p>
+    ${ref}
+    <p style="margin:0;color:#6b7280;font-size:13px;line-height:1.5;">
+      Funds typically appear in your account within 1–2 business days for
+      Stripe, or instantly for Lightning. Reach out to the seller if you
+      don't see them.
+    </p>
+    ${unsubscribeFooter(params.unsubscribeUrl)}`;
+  return {
+    subject: `${BRAND_NAME} — Affiliate payout sent (${amount})`,
+    html: baseTemplate("Affiliate payout sent", body),
+    headers: params.unsubscribeUrl
+      ? {
+          "List-Unsubscribe": `<${params.unsubscribeUrl}>`,
+          "List-Unsubscribe-Post": "List-Unsubscribe=One-Click",
+        }
+      : undefined,
+  };
+}
+
+export function affiliatePausedToAffiliateEmail(params: {
+  affiliateName: string;
+  reason: string;
+  unsubscribeUrl?: string | null;
+}): { subject: string; html: string; headers?: Record<string, string> } {
+  const body = `
+    <h2 style="margin:0 0 16px;color:#111827;font-size:20px;font-weight:700;">Your payouts have been paused</h2>
+    <p style="margin:0 0 16px;color:#374151;font-size:15px;line-height:1.6;">
+      Hi ${esc(params.affiliateName)}, automated payouts on your affiliate
+      account have been paused after several consecutive failures.
+    </p>
+    <p style="margin:0 0 16px;color:#374151;font-size:15px;line-height:1.6;">
+      Last error reported: <em>${esc(params.reason)}</em>
+    </p>
+    <p style="margin:0;color:#6b7280;font-size:13px;line-height:1.5;">
+      Please open your affiliate self-service link and double-check your
+      Lightning address or Stripe Connect account, then reach out to the
+      seller to re-enable payouts.
+    </p>
+    ${unsubscribeFooter(params.unsubscribeUrl)}`;
+  return {
+    subject: `${BRAND_NAME} — Affiliate payouts paused`,
+    html: baseTemplate("Affiliate payouts paused", body),
+    headers: params.unsubscribeUrl
+      ? {
+          "List-Unsubscribe": `<${params.unsubscribeUrl}>`,
+          "List-Unsubscribe-Post": "List-Unsubscribe=One-Click",
+        }
+      : undefined,
+  };
+}
+
+export function affiliatePausedToSellerEmail(params: {
+  affiliateName: string;
+  reason: string;
+  failureCount: number;
+}): { subject: string; html: string } {
+  const body = `
+    <h2 style="margin:0 0 16px;color:#111827;font-size:20px;font-weight:700;">Affiliate payouts paused</h2>
+    <p style="margin:0 0 16px;color:#374151;font-size:15px;line-height:1.6;">
+      Automated payouts to your affiliate <strong>${esc(params.affiliateName)}</strong>
+      have been paused after ${params.failureCount} consecutive failed
+      attempts.
+    </p>
+    <p style="margin:0 0 16px;color:#374151;font-size:15px;line-height:1.6;">
+      Last error: <em>${esc(params.reason)}</em>
+    </p>
+    <p style="margin:0;color:#6b7280;font-size:13px;line-height:1.5;">
+      Open the Affiliates tab in your dashboard to investigate and
+      re-enable payouts once the underlying issue is resolved.
+    </p>`;
+  return {
+    subject: `${BRAND_NAME} — Affiliate payouts paused (${esc(params.affiliateName)})`,
+    html: baseTemplate("Affiliate payouts paused", body),
+  };
+}
+
 export function accountRecoveryEmail(params: { recoveryLink: string }): {
   subject: string;
   html: string;

--- a/utils/email/unsubscribe-tokens.ts
+++ b/utils/email/unsubscribe-tokens.ts
@@ -1,0 +1,112 @@
+/**
+ * Affiliate-email unsubscribe tokens.
+ *
+ * We don't want to email an unsubscribe URL that exposes the affiliate's
+ * invite token (the invite token doubles as auth for editing the payout
+ * destination). Instead we mint a separate token from
+ * `(affiliateId, issuedAtMs, AFFILIATE_UNSUBSCRIBE_SECRET)` so:
+ *  - the unsubscribe URL never exposes the invite token,
+ *  - operators can rotate `AFFILIATE_UNSUBSCRIBE_SECRET` to invalidate every
+ *    outstanding link at once,
+ *  - individual links naturally expire after `UNSUBSCRIBE_TOKEN_TTL_MS`
+ *    (default 1 year) so a years-old archived email can't unsubscribe a
+ *    re-engaged affiliate.
+ *
+ * Token format: `<affiliateId>.<issuedAtMs>.<mac32>`
+ *
+ * The MAC binds both the affiliate id and the issued-at timestamp, so an
+ * attacker can neither forge a fresh timestamp nor swap one affiliate's
+ * timestamp onto another's token.
+ */
+import { createHmac, timingSafeEqual } from "crypto";
+
+const UNSUBSCRIBE_TOKEN_TTL_MS = 365 * 24 * 60 * 60 * 1000; // 1 year
+
+function getSecret(): string {
+  const s = process.env.AFFILIATE_UNSUBSCRIBE_SECRET;
+  if (!s || s.length < 16) {
+    throw new Error(
+      "AFFILIATE_UNSUBSCRIBE_SECRET must be set to a string >= 16 chars"
+    );
+  }
+  return s;
+}
+
+/**
+ * Boot-time validation. Call from the app's module-init path so a missing
+ * secret fails the deploy instead of silently sending unsigned emails.
+ * Safe to call repeatedly. Throws in production, warns in dev/test so local
+ * runs aren't blocked by an unset secret.
+ */
+export function assertAffiliateUnsubscribeSecretConfigured(): void {
+  const s = process.env.AFFILIATE_UNSUBSCRIBE_SECRET;
+  if (!s || s.length < 16) {
+    const msg =
+      "AFFILIATE_UNSUBSCRIBE_SECRET is missing or too short (need >= 16 chars). " +
+      "Affiliate emails will be sent without RFC 8058 unsubscribe headers and " +
+      "any one-click unsubscribe attempts will 500.";
+    if (process.env.NODE_ENV === "production") {
+      throw new Error(msg);
+    }
+    // eslint-disable-next-line no-console
+    console.warn(`[affiliates] ${msg}`);
+  }
+}
+
+function macFor(affiliateId: number, issuedAtMs: number): string {
+  return createHmac("sha256", getSecret())
+    .update(`affiliate-unsub:${affiliateId}:${issuedAtMs}`)
+    .digest("hex")
+    .slice(0, 32);
+}
+
+export function mintAffiliateUnsubscribeToken(
+  affiliateId: number,
+  nowMs: number = Date.now()
+): string {
+  return `${affiliateId}.${nowMs}.${macFor(affiliateId, nowMs)}`;
+}
+
+export function verifyAffiliateUnsubscribeToken(
+  token: string,
+  nowMs: number = Date.now()
+): { affiliateId: number } | null {
+  if (typeof token !== "string") return null;
+  const parts = token.split(".");
+  if (parts.length !== 3) return null;
+  const [idPart, tsPart, macPart] = parts as [string, string, string];
+  const affiliateId = Number(idPart);
+  const issuedAtMs = Number(tsPart);
+  if (!Number.isInteger(affiliateId) || affiliateId <= 0) return null;
+  if (!Number.isInteger(issuedAtMs) || issuedAtMs <= 0) return null;
+  // Reject tokens issued in the future (clock skew tolerance: 5 minutes) or
+  // older than the TTL.
+  if (issuedAtMs > nowMs + 5 * 60 * 1000) return null;
+  if (nowMs - issuedAtMs > UNSUBSCRIBE_TOKEN_TTL_MS) return null;
+  let expected: string;
+  try {
+    expected = macFor(affiliateId, issuedAtMs);
+  } catch {
+    return null;
+  }
+  if (macPart.length !== expected.length) return null;
+  const a = new Uint8Array(Buffer.from(macPart, "utf8"));
+  const b = new Uint8Array(Buffer.from(expected, "utf8"));
+  const ok = timingSafeEqual(a, b);
+  return ok ? { affiliateId } : null;
+}
+
+/**
+ * Mint the absolute unsubscribe URL embedded in affiliate emails. We accept
+ * `baseUrl` as a parameter rather than reading env at call time so tests
+ * stay deterministic.
+ */
+export function buildAffiliateUnsubscribeUrl(
+  baseUrl: string,
+  affiliateId: number
+): string {
+  const trimmed = baseUrl.replace(/\/+$/, "");
+  return `${trimmed}/api/affiliates/unsubscribe?token=${encodeURIComponent(
+    mintAffiliateUnsubscribeToken(affiliateId)
+  )}`;
+}

--- a/utils/nostr/request-auth.ts
+++ b/utils/nostr/request-auth.ts
@@ -8,7 +8,7 @@ export const SIGNED_HTTP_REQUEST_KIND = 27235;
 export const SIGNED_HTTP_REQUEST_MAX_AGE_SECONDS = 300;
 
 type ProofValue = string | number | null | undefined;
-type ProofMethod = "GET" | "POST" | "DELETE";
+type ProofMethod = "GET" | "POST" | "PATCH" | "DELETE";
 
 export type SignedHttpRequestProof = {
   action: string;
@@ -320,6 +320,177 @@ export function buildListFailedRelayPublishesProof(
     method: "GET",
     path: "/api/db/get-failed-publishes",
     pubkey,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Affiliate program proofs (seller-side CRUD + payout management)
+// ---------------------------------------------------------------------------
+
+export function buildAffiliatesListProof(
+  pubkey: string
+): SignedHttpRequestProof {
+  return {
+    action: "list_affiliates",
+    method: "GET",
+    path: "/api/affiliates/manage",
+    pubkey,
+  };
+}
+
+export function buildAffiliateCreateProof({
+  pubkey,
+  name,
+}: {
+  pubkey: string;
+  name: string;
+}): SignedHttpRequestProof {
+  return {
+    action: "create_affiliate",
+    method: "POST",
+    path: "/api/affiliates/manage",
+    pubkey,
+    fields: { name },
+  };
+}
+
+export function buildAffiliateUpdateProof({
+  pubkey,
+  affiliateId,
+}: {
+  pubkey: string;
+  affiliateId: number;
+}): SignedHttpRequestProof {
+  return {
+    action: "update_affiliate",
+    method: "PATCH",
+    path: "/api/affiliates/manage",
+    pubkey,
+    fields: { affiliateId },
+  };
+}
+
+export function buildAffiliateDeleteProof({
+  pubkey,
+  affiliateId,
+}: {
+  pubkey: string;
+  affiliateId: number;
+}): SignedHttpRequestProof {
+  return {
+    action: "delete_affiliate",
+    method: "DELETE",
+    path: "/api/affiliates/manage",
+    pubkey,
+    fields: { affiliateId },
+  };
+}
+
+export function buildAffiliateCodeCreateProof({
+  pubkey,
+  affiliateId,
+  code,
+}: {
+  pubkey: string;
+  affiliateId: number;
+  code: string;
+}): SignedHttpRequestProof {
+  return {
+    action: "create_affiliate_code",
+    method: "POST",
+    path: "/api/affiliates/codes",
+    pubkey,
+    fields: { affiliateId, code },
+  };
+}
+
+export function buildAffiliateCodeUpdateProof({
+  pubkey,
+  codeId,
+}: {
+  pubkey: string;
+  codeId: number;
+}): SignedHttpRequestProof {
+  return {
+    action: "update_affiliate_code",
+    method: "PATCH",
+    path: "/api/affiliates/codes",
+    pubkey,
+    fields: { codeId },
+  };
+}
+
+export function buildAffiliateCodeDeleteProof({
+  pubkey,
+  codeId,
+}: {
+  pubkey: string;
+  codeId: number;
+}): SignedHttpRequestProof {
+  return {
+    action: "delete_affiliate_code",
+    method: "DELETE",
+    path: "/api/affiliates/codes",
+    pubkey,
+    fields: { codeId },
+  };
+}
+
+export function buildAffiliateCodesListProof(
+  pubkey: string
+): SignedHttpRequestProof {
+  return {
+    action: "list_affiliate_codes",
+    method: "GET",
+    path: "/api/affiliates/codes",
+    pubkey,
+  };
+}
+
+export function buildAffiliatePayoutsListProof(
+  pubkey: string
+): SignedHttpRequestProof {
+  return {
+    action: "list_affiliate_payouts",
+    method: "GET",
+    path: "/api/affiliates/payouts",
+    pubkey,
+  };
+}
+
+export function buildAffiliateMarkPaidProof({
+  pubkey,
+  affiliateId,
+  amountSmallest,
+  currency,
+}: {
+  pubkey: string;
+  affiliateId: number;
+  amountSmallest: number;
+  currency: string;
+}): SignedHttpRequestProof {
+  return {
+    action: "mark_affiliate_paid",
+    method: "POST",
+    path: "/api/affiliates/mark-paid",
+    pubkey,
+    fields: { affiliateId, amountSmallest, currency },
+  };
+}
+
+export function buildAffiliateProcessPayoutsProof({
+  pubkey,
+  schedule,
+}: {
+  pubkey: string;
+  schedule: string;
+}): SignedHttpRequestProof {
+  return {
+    action: "process_affiliate_payouts",
+    method: "POST",
+    path: "/api/affiliates/process-payouts",
+    pubkey,
+    fields: { schedule },
   };
 }
 

--- a/utils/nostr/request-auth.ts
+++ b/utils/nostr/request-auth.ts
@@ -494,6 +494,51 @@ export function buildAffiliateProcessPayoutsProof({
   };
 }
 
+export function buildAffiliateReverseReferralProof({
+  pubkey,
+  orderId,
+  sellerPubkey,
+}: {
+  pubkey: string;
+  orderId: string;
+  sellerPubkey: string;
+}): SignedHttpRequestProof {
+  return {
+    action: "reverse_affiliate_referral",
+    method: "POST",
+    path: "/api/affiliates/reverse-referral",
+    pubkey,
+    fields: { orderId, sellerPubkey },
+  };
+}
+
+export function buildAffiliateClickStatsProof(
+  pubkey: string
+): SignedHttpRequestProof {
+  return {
+    action: "list_affiliate_click_stats",
+    method: "GET",
+    path: "/api/affiliates/click-stats",
+    pubkey,
+  };
+}
+
+export function buildAffiliateClaimUpdateProof({
+  pubkey,
+  inviteToken,
+}: {
+  pubkey: string;
+  inviteToken: string;
+}): SignedHttpRequestProof {
+  return {
+    action: "update_affiliate_claim",
+    method: "POST",
+    path: "/api/affiliates/claim",
+    pubkey,
+    fields: { inviteToken },
+  };
+}
+
 export function buildClearFailedRelayPublishProof({
   pubkey,
   eventId,


### PR DESCRIPTION
- Database + helpers for affiliates, codes, referrals, and payouts
- Auth proofs for seller-side CRUD and balance/payout actions (PATCH support added)
- API endpoints including a cron-protected payout processor
- Stripe integration capping the rebate, paying connected affiliates in real time, and accruing otherwise
- Seller dashboard as a new "Affiliates" tab in My Listings
- Affiliate self-service page at /affiliate/[token] plus a global ?ref=CODE cookie tracker mounted in _app.tsx
- Cart integration: cookie-based pre-fill, discount-code-input fallback to affiliate validation, affiliate fields attached to the payment intent, and record-referral posted on Stripe and Cashu success